### PR TITLE
fix(pkg/arch): Do not ignore images without OS

### DIFF
--- a/pkg/arch/hook.go
+++ b/pkg/arch/hook.go
@@ -321,7 +321,7 @@ func (h *Handler) updatePodSpec(ctx context.Context, namespace string, podLabels
 
 		imageArchitectures := map[string]struct{}{}
 		for _, platform := range platforms {
-			if platform.OS != h.systemOS {
+			if platform.OS != "" && platform.OS != h.systemOS {
 				log.DefaultLogger.WithContext(ctx).WithField("os", platform.OS).Info("Skipped OS does not match system's")
 				continue
 			}


### PR DESCRIPTION
Background
=====

Noe goes through all the images available and skips the ones that do not match the host Operating System, so we don't end up running a container with a different OS than the host.

Problem
=====

In some cases, the images come with the `architecture` key but not the `OS` in the manifest file. This causes the `Noe` to skip the image, and to throw an error:

```
Error from server (could not find a common image architecture across all containers): admission webhook "noe.noe.svc" denied the request: could not find a common image architecture across all containers
```

Problem reproduction
=====

To reproduce the problem, you run the following command:

```
kubectl run curl-wlapi --image=radial/busyboxplus:curl -i --tty --rm
```

This returns a message:

```
Error from server (could not find a common image architecture across all containers): admission webhook "noe.noe.svc" denied the request: could not find a common image architecture across all containers
```

Goal
=====

To only compare the Manifest image and host OS when the image has the the field. If the field is not present, then we should not compare them.

Change-Id: Iacbb8082cd9c03088c9974876db9df5ee9975422