### PR TITLE
Support vnd.oci.image.index.v1+json media type for choosing the architecture

### DIFF
--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -228,6 +228,81 @@ func TestListArchsWithAuthenticationAndManifestListV2(t *testing.T) {
 	assert.Contains(t, platforms, Platform{Architecture: "arm64", OS: "linux", Variant: "v8"})
 }
 
+func TestListArchsWithAuthenticationAndManifestIndexV1(t *testing.T) {
+	registry := NewPlainRegistry(WithTransport(httputils.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		switch req.Method {
+		case "HEAD":
+			// simulate a registry requesting authentication
+			// TODO: fix wwwauthenticate authenticating each sub request
+			//assert.Equal(t, "https://registry.company.corp/v2/my/image/manifests/latest", req.URL.String())
+			headers := http.Header{}
+			headers.Set("Www-Authenticate", "Bearer realm=\"https://auth.comnpany.corp/token\",service=\"registry.company.corp\"")
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Header:     headers,
+			}, nil
+		case "GET":
+			switch req.URL.Host {
+			case "auth.comnpany.corp":
+				assert.Equal(t, "/token", req.URL.Path)
+				assert.Equal(t, "registry.company.corp", req.URL.Query().Get("service"))
+				assert.Equal(t, "repository:my/image:pull", req.URL.Query().Get("scope"))
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(strings.NewReader(`{"token":"my-token"}`)),
+				}, nil
+			case "registry.company.corp":
+				switch req.URL.Path {
+				case "/v2/my/image/manifests/latest":
+					headers := http.Header{}
+					headers.Set("Content-Type", "application/vnd.oci.image.index.v1+json")
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Header:     headers,
+						Body: ioutil.NopCloser(strings.NewReader(`{
+							"manifests":[
+								{
+									"platform":{
+										"architecture":"unknown",
+										"os":"unknown"
+									},
+									"digest":"amd-digest"
+								},
+								{
+									"platform":{
+										"architecture":"arm64",
+										"os":"linux",
+										"variant":"v8"
+									},
+									"digest":"arm-digest"
+								}
+							]
+						}`)),
+					}, nil
+				case "/v2/my/image/manifests/arm-digest", "/v2/my/image/manifests/amd-digest":
+					return &http.Response{
+						StatusCode: http.StatusOK,
+					}, nil
+				default:
+					t.Errorf("unexpected %v to %v", req.Method, req.URL)
+				}
+			default:
+				t.Errorf("unexpected %v to %v", req.Method, req.URL)
+			}
+		default:
+			t.Errorf("unexpected %v to %v", req.Method, req.URL)
+		}
+		assert.Equal(t, "Bearer some-token", req.Header.Get("Authorization"))
+		t.Fail()
+		return nil, nil
+	})))
+	platforms, err := registry.ListArchs(context.Background(), "", "registry.company.corp/my/image")
+	assert.NoError(t, err)
+	assert.Len(t, platforms, 1)
+	assert.NotContains(t, platforms, Platform{Architecture: "unknown", OS: "unknown"})
+	assert.Contains(t, platforms, Platform{Architecture: "arm64", OS: "linux", Variant: "v8"})
+}
+
 func TestListArchsWithAuthenticationAndPlainManifest(t *testing.T) {
 	registry := NewPlainRegistry(WithTransport(httputils.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		switch req.Method {


### PR DESCRIPTION
We have perceived that some images built to support arm64 architectures, were not being scheduled in the right nodes unless this was forced.

While doing some research on the information persisted on an image registry for this artifact, we've detected that the mediaType interface on which this manifest is served, is not being taken into account by noe's code, thus not being supported, and expecting values that are not in the structure served by this endpoint.

An example response is:

    ```

    {
        "mediaType": "application/vnd.oci.image.index.v1+json",
        "schemaVersion": 2,
        "manifests": [
            {
                "mediaType": "application/vnd.oci.image.manifest.v1+json",
                "digest": "test-test",
                "size": 676,
                "platform": {
                    "architecture": "arm64",
                    "os": "linux"
                }
            }
        ]
    }

    ```

Since noe expects to have a `platform` key value in the main object, and it's not specified here, the code will assume an assignment of a default value (amd64), and set the node selector accordingly.

This pull request is adding the support for this new media type, which will allow the right platform to be recognized. The current structure to unmarshal the response is working accordingly and does not require further changes.

Also, there is a serialized value for the platform labeled as "unknown", which is being filtered out to avoid issues.