### PR TITLE
Don't error when no image is found

### DIFF
--- a/pkg/arch/hook.go
+++ b/pkg/arch/hook.go
@@ -339,6 +339,11 @@ func (h *Handler) updatePodSpec(ctx context.Context, namespace string, podLabels
 			}
 		}
 	}
+	if firstImage {
+		log.DefaultLogger.WithContext(ctx).Println("no image found")
+		h.addPodNodeMatchingLabels(namespace, podLabels, podSpec)
+		return nil
+	}
 	ctx = log.AddLogFieldsToContext(ctx, logrus.Fields{"compatibleImages": commonArchitectures})
 	if len(commonArchitectures) == 0 {
 		log.DefaultLogger.WithContext(ctx).Println("no common architecture")

--- a/pkg/registry/cache_test.go
+++ b/pkg/registry/cache_test.go
@@ -173,12 +173,18 @@ func TestCachedRegistry(t *testing.T) {
 	t.Run("error case", func(t *testing.T) {
 
 		cr := NewCachedRegistry(registryFunc, cacheDuration)
+		calls := 0
 		errorRegistryFunc := RegistryFunc(func(ctx context.Context, imagePullSecret, image string) ([]Platform, error) {
+			calls++
 			return nil, errors.New("error")
 		})
 		cr.registry = errorRegistryFunc
 		archs, err := cr.ListArchs(ctx, "secret", "image-in-error")
 		assert.Error(t, err)
 		assert.Nil(t, archs)
+		archs, err = cr.ListArchs(ctx, "secret", "image-in-error")
+		assert.Error(t, err)
+		assert.Nil(t, archs)
+		assert.Equal(t, 2, calls, "Errors should not be cached, registry should be called twice")
 	})
 }

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -303,6 +303,12 @@ func TestListArchsWithAuthenticationAndManifestIndexV1(t *testing.T) {
 	assert.Contains(t, platforms, Platform{Architecture: "arm64", OS: "linux", Variant: "v8"})
 }
 
+func TestListArchWithEmptyImage(t *testing.T) {
+	registry := NewPlainRegistry()
+	_, err := registry.ListArchs(context.Background(), "", "")
+	assert.NoError(t, err)
+}
+
 func TestListArchsWithAuthenticationAndPlainManifest(t *testing.T) {
 	registry := NewPlainRegistry(WithTransport(httputils.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		switch req.Method {

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -306,7 +306,7 @@ func TestListArchsWithAuthenticationAndManifestIndexV1(t *testing.T) {
 func TestListArchWithEmptyImage(t *testing.T) {
 	registry := NewPlainRegistry()
 	_, err := registry.ListArchs(context.Background(), "", "")
-	assert.NoError(t, err)
+	assert.Error(t, err)
 }
 
 func TestListArchsWithAuthenticationAndPlainManifest(t *testing.T) {


### PR DESCRIPTION
Problem
---

Currently, when no image can be found in a pod, noe is failing hard with a message that there is no common image archtecture across all containers.

This is misleading.

Goal
---

Make sure that if there is no image, noe does not change the node selector