### PR TITLE
Fix RegistryAuthenticator filesystem

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -27,7 +27,7 @@ var DefaultRegistry = NewPlainRegistry()
 func NewPlainRegistry(builders ...func(*PlainRegistry)) PlainRegistry {
 	r := PlainRegistry{
 		Scheme:        "https",
-		Authenticator: RegistryAuthenticator{fs: afero.NewMemMapFs()},
+		Authenticator: RegistryAuthenticator{fs: afero.NewOsFs()},
 		Proxies:       []RegistryProxy{},
 	}
 	for _, builder := range builders {


### PR DESCRIPTION
RegistryAuthenticator was initializated with a mock of filesystem instead of OS filesystem.

This prevented to use containerd support.

Registry instances RegistryAuthenticator with a filesystem.
This filesystem is being used here:
https://github.com/adevinta/noe/blob/main/pkg/registry/login.go#L124

To walk over:
```
"/etc/containerd"
```

https://github.com/adevinta/noe/blob/main/pkg/registry/login.go#L217

As the filesystem is being mocked, it wont walk over the directory and it wont be able to use containerd.

Once this is solved merging this PR you would find this type of logs:
```
{"level":"info","msg":"Get containerd auth for https://docker.io","time":"2023-12-15T13:16:12Z"}
```

https://github.com/adevinta/noe/blob/main/pkg/registry/login.go#L150
