### PR TITLE
NOJIRA Break PodReconciler.Reconcile() into helpers

### DIFF
--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -127,7 +127,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	}
 
 	if apierrors.IsNotFound(err) {
-		r.deleteFromCaches(req.NamespacedName.String())
+		r.deleteFromCache(req.NamespacedName.String())
 		return ctrl.Result{}, nil
 	}
 	if r.isImageCached(req.NamespacedName.String()) || podIsReady(ctx, pod) {
@@ -221,7 +221,7 @@ func (r *PodReconciler) isImageCached(namespacedName string) bool {
 	return ok
 }
 
-func (r *PodReconciler) deleteFromCaches(namespacedName string) {
+func (r *PodReconciler) deleteFromCache(namespacedName string) {
 	images, ok := r.podImages[namespacedName]
 	if ok {
 		for _, image := range images {

--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -248,7 +248,7 @@ func (r *PodReconciler) podScheduledOnMatchingNode(ctx context.Context, namespac
 	return ctx, podScheduledOnMatchingNode, nil
 }
 
-func (r *PodReconciler) addToCaches(namespacedName string, podImages []string) {
+func (r *PodReconciler) addToCache(namespacedName string, podImages []string) {
 	r.podImages[namespacedName] = podImages
 }
 

--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -252,7 +252,7 @@ func (r *PodReconciler) addToCaches(namespacedName string, podImages []string) {
 	r.podImages[namespacedName] = podImages
 }
 
-func (r *PodReconciler) checkImageCached(namespacedName string) bool {
+func (r *PodReconciler) isImageCached(namespacedName string) bool {
 	_, ok := r.podImages[namespacedName]
 	return ok
 }

--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -130,7 +130,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		r.deleteFromCaches(req.NamespacedName.String())
 		return ctrl.Result{}, nil
 	}
-	if r.checkImageCached(req.NamespacedName.String()) || podIsReady(ctx, pod) {
+	if r.isImageCached(req.NamespacedName.String()) || podIsReady(ctx, pod) {
 		log.DefaultLogger.WithContext(ctx).Info("pod was already processed")
 		return ctrl.Result{}, nil
 	}

--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -142,7 +142,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, err
 	}
 
-	r.addToCaches(req.NamespacedName.String(), podImages)
+	r.addToCache(req.NamespacedName.String(), podImages)
 
 	if podScheduledOnMatchingNode {
 		return ctrl.Result{}, nil


### PR DESCRIPTION
 # Context

The `PodReconciler.Reconcile()` is long and convoluted, making it hard to understand and parse. As there are distinct steps in its operation, let's break them into helpers named after the logical operation to simplify understanding it.

 # What this changes

- Extract interface for caching and platform statistics into its own private methods, starting a new internal API.

- Group all the code required to determine if an existing Pod is already scheduled properly into its own private method.

- Streamline the main method's flow to reduce indentation and clarify the logical process.

 # Non-goals

- Modify the behaviour of the reconcile method

Change-Id: Id39d5caf4120b1f20a138b6dfecd5ae8be344eab