### PR TITLE
bug: StatefulSets are not reevaluated after rescheduling

### DIFF
--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -131,7 +131,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, nil
 	}
 
-	if !skipCache(pod) && (r.isImageCached(req.NamespacedName.String()) || podIsReady(ctx, pod)) {
+	if !isStatefulSet(pod) && (r.isImageCached(req.NamespacedName.String()) || podIsReady(ctx, pod)) {
 		log.DefaultLogger.WithContext(ctx).Info("pod was already processed")
 		return ctrl.Result{}, nil
 	}
@@ -314,15 +314,14 @@ func (r *PodReconciler) deletePodAndNotifyUser(ctx context.Context, pod *v1.Pod)
 	}
 }
 
-func skipCache(pod *v1.Pod) bool {
-	skipCache := false
+func isStatefulSet(pod *v1.Pod) bool {
 	owners := pod.GetOwnerReferences()
 	for _, owner := range owners {
 		if owner.Kind == "StatefulSet" {
 			return true
 		}
 	}
-	return skipCache
+	return false
 }
 
 // podIsReady checks if a pod condition is ready which means the readiness probe of all containers are OK.


### PR DESCRIPTION
 # Context

Noe caches the Pods it has already processed to avoid reprocessing
them unless there are changes. We do this by storing the
`NamespacedName` of the Pod, which includes the namespace and Pod
name.

For Deployments, rescheduling the Pod actually changes its name as the
termination is generated. For StatefulSets, the name is kept the same
no matter how many reschedules happen.

Our caching approach prevents us form reevaluating the location of
StatefulSet pods if they were previously scheduled, and we've seen
this allocate StatefulSet pods to nodes whose architectures where not
supported by the Pod.

 # Bugfix approach

The intention of the cache is to reduce load over Registries and Noe
itself. In our case so far StatefulSets are much less common than
Deployments, so we choose to avoid the cache for StatefulSets.

This is a stopgap measure to prevent misscheduling of current
workloads until a better approach to prevent reprocessing of Pods can
be devised that supports StatefulSets.

 # What we change

We add a `skipCache(*v1.Pod)` function that checks if the Pod is owned
by a StatefulSet. If so, the caching mechanism is skipped for this
workload.