### PR TITLE
Schedulable archs flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ spec:
     targetRevision: HEAD
 ```
 
-## Hinting preferred target architecture
+## Hinting preferred and supported target architectures
 
 By default, Noe will automatically select the appropriate architecture when only one is supported by all the containers in the Pod. 
 If more than one is available, Noe will select the system-defined preferred one if available. This preference can be chosen in the command line for Noe (defaults to `amd64` if unspecified): 
@@ -49,3 +49,13 @@ labels:
 ```
 
 Noe will always prioritize a running Pod, so if the preference is not supported by all the containers in the Pod, the common architecture will be selected.
+
+You can restrict the acceptable common architectures in the command line for Noe:
+```
+./noe -cluster-schedulable-archs amd64,arm64
+```
+
+If you specify both a preferred architecture and a list of supported architectures in the command line, the default architecture must be part of the list. Otherwise Noe will fail to start.
+
+If a preferred architecture is specified at the Pod level and is not compatible with the supported architectures listed in the command line, it will be ignored.
+

--- a/charts/noe/templates/webhook.yaml
+++ b/charts/noe/templates/webhook.yaml
@@ -55,6 +55,7 @@ spec:
         workingDir: /workdir
         args:
         - registry-proxies={{ .Values.proxies | join "," }}
+        - cluster-schedulable-archs={{ .Values.schedulableArchitectures | join "," }}
         ports:
         - containerPort: 8443
           name: webhook

--- a/charts/noe/values.yaml
+++ b/charts/noe/values.yaml
@@ -6,6 +6,7 @@ image:
   registry: ghcr.io
   repository: adevinta/noe
   tag: latest
+schedulableArchitectures: []
 proxies: []
 # - docker.io=docker-proxy.company.corp
 # - quay.io=quay-proxy.company.corp

--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/adevinta/noe/pkg/httputils"
@@ -22,21 +24,43 @@ import (
 )
 
 func main() {
-	var preferredArch, systemOS string
+	var preferredArch, schedulableArchs, systemOS string
 	var metricsAddr string
 	var registryProxies, matchNodeLabels string
 
 	flag.StringVar(&preferredArch, "preferred-arch", "amd64", "Preferred architecture when placing pods")
+	flag.StringVar(&schedulableArchs, "cluster-schedulable-archs", "", "Comma separated list of architectures schedulable in the cluster")
 	flag.StringVar(&systemOS, "system-os", "linux", "Sole OS supported by the system")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&metricsAddr, "registry-proxies", "", "Proxies to substitute in the registry URL in the form of docker.io=docker-proxy.company.corp,quay.io=quay-proxy.company.corp")
 	flag.StringVar(&matchNodeLabels, "match-node-labels", "", "A set of pod label keys to match against node labels in the form of key1,key2")
 	flag.Parse()
 
-	Main(signals.SetupSignalHandler(), "./", preferredArch, systemOS, metricsAddr, registryProxies, matchNodeLabels)
+	Main(signals.SetupSignalHandler(), "./", preferredArch, schedulableArchs, systemOS, metricsAddr, registryProxies, matchNodeLabels)
 }
 
-func Main(ctx context.Context, certDir, preferredArch, systemOS, metricsAddr, registryProxies, matchNodeLabels string) {
+func Main(ctx context.Context, certDir, preferredArch, schedulableArchs, systemOS, metricsAddr, registryProxies, matchNodeLabels string) {
+	var schedulableArchSlice []string
+
+	if schedulableArchs != "" {
+		schedulableArchSlice = strings.Split(schedulableArchs, ",")
+	}
+
+	if preferredArch != "" && schedulableArchs != "" {
+		supported := false
+		for _, schedulableArch := range schedulableArchSlice {
+			if preferredArch == schedulableArch {
+				supported = true
+				break
+			}
+		}
+
+		if !supported {
+			err := fmt.Errorf("preferred architecture is not schedulable in the cluster")
+			log.DefaultLogger.WithError(err).Error("refusing to continue")
+			os.Exit(1)
+		}
+	}
 
 	// Setup a Manager
 	log.DefaultLogger.WithContext(ctx).Println("setting up manager")
@@ -90,6 +114,7 @@ func Main(ctx context.Context, certDir, preferredArch, systemOS, metricsAddr, re
 			containerRegistry,
 			arch.WithMetricsRegistry(metrics.Registry),
 			arch.WithArchitecture(preferredArch),
+			arch.WithSchedulableArchitectures(schedulableArchSlice),
 			arch.WithOS(systemOS),
 			arch.WithDecoder(decoder),
 			arch.WithMatchNodeLabels(arch.ParseMatchNodeLabels(matchNodeLabels)),

--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
@@ -46,20 +47,10 @@ func Main(ctx context.Context, certDir, preferredArch, schedulableArchs, systemO
 		schedulableArchSlice = strings.Split(schedulableArchs, ",")
 	}
 
-	if preferredArch != "" && schedulableArchs != "" {
-		supported := false
-		for _, schedulableArch := range schedulableArchSlice {
-			if preferredArch == schedulableArch {
-				supported = true
-				break
-			}
-		}
-
-		if !supported {
-			err := fmt.Errorf("preferred architecture is not schedulable in the cluster")
-			log.DefaultLogger.WithError(err).Error("refusing to continue")
-			os.Exit(1)
-		}
+	if preferredArch != "" && schedulableArchs != "" && !slices.Contains(schedulableArchSlice, preferredArch) {
+		err := fmt.Errorf("preferred architecture is not schedulable in the cluster")
+		log.DefaultLogger.WithError(err).Error("refusing to continue")
+		os.Exit(1)
 	}
 
 	// Setup a Manager

--- a/cmd/noe/main_test.go
+++ b/cmd/noe/main_test.go
@@ -105,7 +105,7 @@ func TestNoeMain(t *testing.T) {
 	require.NoError(t, err)
 	os.Setenv("KUBECONFIG", env.KubeconfigFile())
 
-	go Main(ctx, "./integration-tests/", "amd64", "linux", ":8181", "", "")
+	go Main(ctx, "./integration-tests/", "amd64", "", "linux", ":8181", "", "")
 
 	client := http.Client{
 		Transport: &http.Transport{

--- a/pkg/arch/hook.go
+++ b/pkg/arch/hook.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -517,13 +518,7 @@ func (h *Handler) isArchSupported(arch string) bool {
 	if len(h.schedulableArchitectures) == 0 {
 		return true
 	}
-
-	for _, schedulableArch := range h.schedulableArchitectures {
-		if arch == schedulableArch {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(h.schedulableArchitectures, arch)
 }
 
 // Handler implements admission.DecoderInjector.

--- a/pkg/arch/hook.go
+++ b/pkg/arch/hook.go
@@ -110,13 +110,14 @@ func (w warning) Error() string {
 
 type HandlerOption func(*Handler)
 type Handler struct {
-	Client                client.Client
-	Registry              Registry
-	matchNodeLabels       []string
-	metrics               HandlerMetrics
-	decoder               *admission.Decoder
-	preferredArchitecture string
-	systemOS              string
+	Client                   client.Client
+	Registry                 Registry
+	matchNodeLabels          []string
+	metrics                  HandlerMetrics
+	decoder                  *admission.Decoder
+	preferredArchitecture    string
+	schedulableArchitectures []string
+	systemOS                 string
 }
 
 func NewHandler(client client.Client, registry Registry, opts ...HandlerOption) *Handler {
@@ -138,6 +139,12 @@ func WithMetricsRegistry(reg metrics.RegistererGatherer) HandlerOption {
 func WithArchitecture(arch string) HandlerOption {
 	return func(h *Handler) {
 		h.preferredArchitecture = arch
+	}
+}
+
+func WithSchedulableArchitectures(archs []string) HandlerOption {
+	return func(h *Handler) {
+		h.schedulableArchitectures = archs
 	}
 }
 
@@ -295,12 +302,16 @@ func (h *Handler) updatePodSpec(ctx context.Context, namespace string, podLabels
 
 	var preferredArchIsDefault bool
 	preferredArch, preferredArchDefined := podLabels["arch.noe.adevinta.com/preferred"]
+	if preferredArch != "" && !h.isArchSupported(preferredArch) {
+		log.DefaultLogger.WithContext(ctx).WithField("preferredArch", preferredArch).Println("ignoring unsupported user preferred architecture")
+		preferredArch = ""
+	}
 	if preferredArch == "" && h.preferredArchitecture != "" {
 		preferredArch = h.preferredArchitecture
 		preferredArchDefined = true
 		preferredArchIsDefault = true
 		ctx = log.AddLogFieldsToContext(ctx, logrus.Fields{"preferredArch": preferredArch})
-		log.DefaultLogger.WithContext(ctx).Println("selecting preferred architecture")
+		log.DefaultLogger.WithContext(ctx).Println("selecting default preferred architecture")
 	}
 
 	commonArchitectures := map[string]struct{}{}
@@ -323,6 +334,10 @@ func (h *Handler) updatePodSpec(ctx context.Context, namespace string, podLabels
 		for _, platform := range platforms {
 			if platform.OS != "" && platform.OS != h.systemOS {
 				log.DefaultLogger.WithContext(ctx).WithField("os", platform.OS).Info("Skipped OS does not match system's")
+				continue
+			}
+			if !h.isArchSupported(platform.Architecture) {
+				log.DefaultLogger.WithContext(ctx).WithField("arch", platform.OS).Info("Skipped arch does not match system's")
 				continue
 			}
 			imageArchitectures[platform.Architecture] = struct{}{}
@@ -496,6 +511,19 @@ func (h *Handler) Handle(ctx context.Context, req admission.Request) admission.R
 		resp = admission.Allowed(fmt.Sprintf("nothing to do for type %v", req.Kind.Kind))
 	}
 	return resp
+}
+
+func (h *Handler) isArchSupported(arch string) bool {
+	if len(h.schedulableArchitectures) == 0 {
+		return true
+	}
+
+	for _, schedulableArch := range h.schedulableArchitectures {
+		if arch == schedulableArch {
+			return true
+		}
+	}
+	return false
 }
 
 // Handler implements admission.DecoderInjector.


### PR DESCRIPTION
 # Context

In some cases we have seen that the common architectures of the images
do not match the default preferred architecture. In those cases, one
of the common architectures is selected, which may not match the
available architectures in the cluster. In those cases, the Pod is
always pending scheduling waiting for a node that will never exist.

 # Approach

Allow passing a comma-separated list of architectures schedulable in
the cluster. As we detect image's architecture support, we ignore
those architectures that have not been specified as supported by the
cluster.

This new flag is optional and defaults to empty string (which disables
the feature and keeps the prior behaviour).

 ## Startup fail if preferred architecture is not part of the supported architectures

Startup will fail if the preferred architecture selected via
commandline is not part of the list of schedulable architectures to
prevent misconfigurations.

 ## Ignore preferred arch at Pod level if unsupported

If a preferred architecture is indicated at Pod level, but it does not
belong to the list of schedulable architectures, we ignore the preference
and treat it as not specified. A log line is generated in that case.

 # Non-goal

 ## Detect architectures present in the cluster

We do not want to prevent scheduling of Pods with architectures
supported but which have no nodes currently in the cluster
(downscaled) to avoid interfering with scale from 0 set ups.
