### PR TITLE
Bump golang to 1.21

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v3
       with:
-        go-version: '^1.19'
+        go-version: '^1.21'
   
     - name: Set up Docker context for Buildx
       id: buildx-context

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
     - name: Setup Golang
       uses: actions/setup-go@v3
       with:
-        go-version: '1.20'
+        go-version: '1.21'
 
     - name: run go tests
       run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/adevinta/noe
 
-go 1.20
+go 1.21
 
 require (
 	github.com/abbot/go-http-auth v0.4.0


### PR DESCRIPTION
To use some recent language libraries we have to bump our go version to 1.21+, including the CI.
