### PR TITLE
Address deprecations and dead code

### DIFF
--- a/pkg/arch/hook.go
+++ b/pkg/arch/hook.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
-	"sort"
 	"strings"
 	"time"
 
@@ -633,7 +632,7 @@ func keys(set map[string]struct{}) []string {
 	for k := range set {
 		r = append(r, k)
 	}
-	sort.Sort(sort.StringSlice(r))
+	slices.Sort(r)
 	return r
 }
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -174,7 +174,7 @@ func TestListArchsWithAuthenticationAndManifestListV2(t *testing.T) {
 				assert.Equal(t, "repository:my/image:pull", req.URL.Query().Get("scope"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token":"my-token"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token":"my-token"}`)),
 				}, nil
 			case "registry.company.corp":
 				switch req.URL.Path {
@@ -184,7 +184,7 @@ func TestListArchsWithAuthenticationAndManifestListV2(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Header:     headers,
-						Body: ioutil.NopCloser(strings.NewReader(`{
+						Body: io.NopCloser(strings.NewReader(`{
 							"manifests":[
 								{
 									"platform":{
@@ -249,7 +249,7 @@ func TestListArchsWithAuthenticationAndManifestIndexV1(t *testing.T) {
 				assert.Equal(t, "repository:my/image:pull", req.URL.Query().Get("scope"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token":"my-token"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token":"my-token"}`)),
 				}, nil
 			case "registry.company.corp":
 				switch req.URL.Path {
@@ -259,7 +259,7 @@ func TestListArchsWithAuthenticationAndManifestIndexV1(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Header:     headers,
-						Body: ioutil.NopCloser(strings.NewReader(`{
+						Body: io.NopCloser(strings.NewReader(`{
 							"manifests":[
 								{
 									"platform":{
@@ -329,7 +329,7 @@ func TestListArchsWithAuthenticationAndPlainManifest(t *testing.T) {
 				assert.Equal(t, "repository:my/image:pull", req.URL.Query().Get("scope"))
 				return &http.Response{
 					StatusCode: http.StatusOK,
-					Body:       ioutil.NopCloser(strings.NewReader(`{"token":"my-token"}`)),
+					Body:       io.NopCloser(strings.NewReader(`{"token":"my-token"}`)),
 				}, nil
 			case "registry.company.corp":
 				switch req.URL.Path {
@@ -339,7 +339,7 @@ func TestListArchsWithAuthenticationAndPlainManifest(t *testing.T) {
 					return &http.Response{
 						StatusCode: http.StatusOK,
 						Header:     headers,
-						Body: ioutil.NopCloser(strings.NewReader(`{
+						Body: io.NopCloser(strings.NewReader(`{
 							"architecture": "amd64"
 						}`)),
 					}, nil


### PR DESCRIPTION
- `ioutil` has been deprecated since Go 1.16, so we can use the replacements.
- `slices.Sort` is simpler and faster than using the `sort` package, and now availabel with Go 1.21.
- Found an unused functions that can be dropped.

Change-Id: If44cceaa2bbba10535cd5c663de4615823d86ba5