### PR TITLE
Add cache metrics

### DIFF
--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -75,7 +75,7 @@ func Main(ctx context.Context, certDir, preferredArch, schedulableArchs, systemO
 			registry.RegistryLabeller,
 		)),
 	)
-	containerRegistry = registry.NewCachedRegistry(containerRegistry, 1*time.Hour)
+	containerRegistry = registry.NewCachedRegistry(containerRegistry, 1*time.Hour, registry.WithCacheMetricsRegistry(metrics.Registry))
 
 	if err = controllers.NewPodReconciler(
 		"noe",

--- a/pkg/registry/cache_test.go
+++ b/pkg/registry/cache_test.go
@@ -9,9 +9,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/adevinta/noe/pkg/metric_test_helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAllMetricsShouldBeRegistered(t *testing.T) {
+	metrics := NewCacheMetrics("test")
+	metric_test_helpers.AssertAllMetricsHaveBeenRegistered(t, metrics)
+}
 
 func TestCachedRegistry(t *testing.T) {
 	platforms := []Platform{


### PR DESCRIPTION
Allow monitoring the rate of cache hits and misses for registry
architectures
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Refactor registry client, extract listArchsWithAuth to dedicated function (#83)
</summary>
We have recently seen that in case an error occurs when getting a single
manifest fails.
In those cases, it could happen that the ListArch func drops some of the
supported architecture, randomly.

Take a step forward towards solving this issue. Isolate retrieving image
architectures for a single authorisation candidate
</details>
<details>
<summary>
Add missing image manifest header (#84)
</summary>
Problem
---

When retrieving image distribution manifest list, we send the request
without any Accept header.

This causes some image registries to return 404, and makes us miss the
real image architectures supported.

This PR ensures that we are able to to fetch individual image manifests
so we can successfully detect the supported architectures for most of
the registries
</details>
<details>
<summary>
Add metrics to the registry client (#85)
</summary>
Allow monitoring the rate of image registry accesses and errors
</details>
</details>
</details>