### PR TITLE
Add missing image manifest header

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -269,7 +269,10 @@ func (r PlainRegistry) listArchsWithAuth(ctx context.Context, client http.Client
 	case "application/vnd.docker.distribution.manifest.list.v2+json", "application/vnd.oci.image.index.v1+json":
 		for _, manifest := range response.Manifests {
 			// Ensure that the pointed image is available
-			resp, err := r.getImageManifest(ctx, client, auth, r.Scheme, registry, image, manifest.Digest)
+			resp, err := r.getImageManifest(ctx, client, auth, r.Scheme, registry, image, manifest.Digest,
+				"application/vnd.oci.image.manifest.v1+json",
+				"application/vnd.docker.distribution.manifest.v2+json",
+			)
 			if err != nil {
 				log.DefaultLogger.WithContext(ctx).Printf("failed to get pointed manifest for arch %s of %s/%s: %v. Skipping\n", manifest.Platform.Architecture, registry, image, err)
 				continue

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -153,6 +153,15 @@ func TestListGithubArch(t *testing.T) {
 	assert.Contains(t, platforms, Platform{Architecture: "arm64", OS: "linux"})
 }
 
+func TestListGithubNoeArch(t *testing.T) {
+	// This image requires the application/vnd.oci.image.manifest.v1+json Accept header to successfully return all architectures
+	platforms, err := DefaultRegistry.ListArchs(context.Background(), "", "ghcr.io/adevinta/noe:latest")
+	require.NoError(t, err)
+	require.NotNil(t, platforms)
+	assert.Contains(t, platforms, Platform{Architecture: "amd64", OS: "linux"})
+	assert.Contains(t, platforms, Platform{Architecture: "arm64", OS: "linux"})
+}
+
 func TestListArchsWithAuthenticationAndManifestListV2(t *testing.T) {
 	registry := NewPlainRegistry(WithTransport(httputils.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
 		switch req.Method {


### PR DESCRIPTION
Problem
---

When retrieving image distribution manifest list, we send the request
without any Accept header.

This causes some image registries to return 404, and makes us miss the
real image architectures supported.

This PR ensures that we are able to to fetch individual image manifests
so we can successfully detect the supported architectures for most of
the registries
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add metrics to the registry client (#85)
</summary>
Allow monitoring the rate of image registry accesses and errors
</details>
</details>
</details>