### PR TITLE
[need #84] Add metrics to the registry client

### DIFF
--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -74,6 +74,7 @@ func Main(ctx context.Context, certDir, preferredArch, schedulableArchs, systemO
 			},
 			registry.RegistryLabeller,
 		)),
+		registry.WithDockerRegistryMetricsRegistry(metrics.Registry),
 	)
 	containerRegistry = registry.NewCachedRegistry(containerRegistry, 1*time.Hour, registry.WithCacheMetricsRegistry(metrics.Registry))
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -9,11 +9,17 @@ import (
 	"testing"
 
 	"github.com/adevinta/noe/pkg/httputils"
+	"github.com/adevinta/noe/pkg/metric_test_helpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 const WellKnownMultiArchImage = "alpine:3.17.2"
+
+func TestAllRegistryMetricsShouldBeRegistered(t *testing.T) {
+	metrics := NewRegistryMetrics("test")
+	metric_test_helpers.AssertAllMetricsHaveBeenRegistered(t, metrics)
+}
 
 func testParseImage(t testing.TB, fullImage, expectedRegistry, expectedImage, expectedTag string, expectedHasRef bool) {
 	t.Helper()


### PR DESCRIPTION
Allow monitoring the rate of image registry accesses and errors
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Parent changes
</summary>
<details>
<summary>
Add missing image manifest header (#84)
</summary>
Problem
---

When retrieving image distribution manifest list, we send the request
without any Accept header.

This causes some image registries to return 404, and makes us miss the
real image architectures supported.

This PR ensures that we are able to to fetch individual image manifests
so we can successfully detect the supported architectures for most of
the registries
</details>
</details>
</details>