### PR TITLE
Run go tests on merge queues

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,9 @@ name: run tests
 on:
   pull_request:
     branches: [ "*" ]
+  push:
+    branches:
+    - "gh-readonly-queue/**/*"
 
 jobs:
   testGo:


### PR DESCRIPTION
Context
---

We have a branch protection on main that requires testGo to run.

Problem
---

When enabling merge queue, github pushes a new commit to a well-known branch (example [here](https://github.com/adevinta/noe/tree/gh-readonly-queue/main/pr-82-33e30e121ca852ceffe875deedc2eeda4e2a4cb7) ).

In the current settings, we don't trigger gha to run on those branches and hence the merge queue is never executed

Goal
---

Make sure that merge queue is actually working as expected