### PR TITLE
Refactor Authenticator to inject the channel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.21
 require (
 	github.com/abbot/go-http-auth v0.4.0
 	github.com/go-logr/logr v1.2.4
+	github.com/google/uuid v1.3.0
 	github.com/guseggert/pkggodev-client v0.0.0-20211029144512-2df8afe3ebe4
 	github.com/pelletier/go-toml v1.9.5
 	github.com/prometheus/client_golang v1.15.1
@@ -46,7 +47,6 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/pkg/registry/login_test.go
+++ b/pkg/registry/login_test.go
@@ -17,7 +17,8 @@ func TestAuthenticateWithimagePullSecret(t *testing.T) {
 
 	authenticator := RegistryAuthenticator{fs: afero.NewMemMapFs()} // Create an instance of the RegistryAuthenticator
 
-	candidates := authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag)
+	candidates := make(chan AuthenticationToken)
+	go authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag, candidates)
 
 	receivedToken, ok := <-candidates
 	assert.True(t, ok, "AuthenticationToken not received")
@@ -63,7 +64,8 @@ func TestRegistryAuthenticator_GetHeaderOnContainerdFiles(t *testing.T) {
 	image := "myimage"
 	tag := "latest"
 
-	candidates := authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag)
+	candidates := make(chan AuthenticationToken)
+	go authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag, candidates)
 
 	receivedToken, ok := <-candidates
 	assert.True(t, ok, "AuthenticationToken not received")


### PR DESCRIPTION
Context
---

We currently suport 2 authentication sources. Docker and containerD.

Problems
---

1. Kubelet has a third one: [CredentialProviderConfig]

To be consistent, noe needs to implement all of those to be able to
lookup the values in the relevant place.

2. The current containerD authentication is mixed with the Docker one (file
and image pull secret ones).

Goal
---

Refactor the authentication provider in order to split them into
one provider by kind of authentication.

This will ease imlement the kubelet authentication and manage the
different authentication mechanisms

[CredentialProviderConfig]: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Refactor authenticators extract Docker and containerd to individual files (#88)
</summary>
Context
---

We currently suport 2 authentication sources. Docker and containerD.

Problems
---

1. Kubelet has a third one: [CredentialProviderConfig]

To be consistent, noe needs to implement all of those to be able to
lookup the values in the relevant place.

2. The current containerD authentication is mixed with the Docker one (file
and image pull secret ones).

Goal
---

Get clearer isolation between the different authentication mechanisms
Ease implementing new authentication methods

[CredentialProviderConfig]: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
</details>
<details>
<summary>
Refactor main entrypoint (#89)
</summary>

</details>
<details>
<summary>
Bump controller-runtime version (#91)
</summary>

</details>
<details>
<summary>
Implement kubelet CredentialProvider (#90)
</summary>
Context
---

We currently suport 2 authentication sources. Docker and containerD.

Problems
---

1. Kubelet has a third one: [CredentialProviderConfig]

To be consistent, noe needs to implement all of those to be able to
lookup the values in the relevant place.

2. The current containerD authentication is mixed with the Docker one (file
and image pull secret ones).

Goal
---

Add supoort for kubelet CredentialProvider

[CredentialProviderConfig]: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
</details>
</details>
</details>