### PR TITLE
Refactor authenticators extract Docker and containerd to individual files

### DIFF
--- a/pkg/registry/anonymous_credentials.go
+++ b/pkg/registry/anonymous_credentials.go
@@ -1,0 +1,13 @@
+package registry
+
+import "context"
+
+type AnonymousAuthenticator struct{}
+
+func (r AnonymousAuthenticator) Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken) {
+	select {
+	case candidates <- AuthenticationToken{}:
+	case <-ctx.Done():
+		return
+	}
+}

--- a/pkg/registry/anonymous_credentials_test.go
+++ b/pkg/registry/anonymous_credentials_test.go
@@ -1,0 +1,17 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAnonymousAuthenticator(t *testing.T) {
+	authenticator := AnonymousAuthenticator{}
+	candidates := make(chan AuthenticationToken, 1)
+	authenticator.Authenticate(context.Background(), "", "", "", "", candidates)
+	candidate := <-candidates
+	assert.Empty(t, candidate.Kind)
+	assert.Empty(t, candidate.Token)
+}

--- a/pkg/registry/containerd_credentials.go
+++ b/pkg/registry/containerd_credentials.go
@@ -1,0 +1,104 @@
+package registry
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/adevinta/noe/pkg/log"
+	"github.com/pelletier/go-toml"
+	"github.com/spf13/afero"
+)
+
+var _ Authenticator = ContainerDAuthenticator{}
+
+type ContainerdHostConfig struct {
+	Capabilities []string         `toml:"capabilities"`
+	Header       ContainerdHeader `toml:"header"`
+}
+
+type ContainerdHeader struct {
+	Authorization string `toml:"authorization"`
+}
+
+type ContainerdConfig struct {
+	Server string                          `toml:"server"`
+	Hosts  map[string]ContainerdHostConfig `toml:"host"`
+}
+
+type ContainerdServerHeader struct {
+	Server string
+	Header string
+}
+
+type ContainerDAuthenticator struct {
+	fs afero.Fs
+}
+
+func (r ContainerDAuthenticator) Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken) {
+	containerdAuth, _ := r.getHeaderOnContainerdFiles(registry, "/etc/containerd")
+	if containerdAuth.Header != "" {
+		log.DefaultLogger.WithContext(ctx).WithField("registry", containerdAuth.Server).WithField("image", fmt.Sprintf("%s/%s", registry, image)).Printf("Image matches registry config. Trying it")
+		select {
+		case candidates <- AuthenticationToken{
+			Kind:  "Basic",
+			Token: containerdAuth.Header,
+		}:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (r ContainerDAuthenticator) getHeaderOnContainerdFiles(repository, directory string) (ContainerdServerHeader, error) {
+	var matchedServerHeader ContainerdServerHeader
+
+	err := afero.Walk(r.fs, directory, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		fileExtension := filepath.Ext(path)
+		if fileExtension != ".toml" {
+			return nil
+		}
+
+		configData, err := afero.ReadFile(r.fs, path)
+		if err != nil {
+			return nil
+		}
+
+		config := ContainerdConfig{}
+		err = toml.Unmarshal(configData, &config)
+		if err != nil {
+			return nil
+		}
+
+		if match, _ := regexp.MatchString(repository, config.Server); match {
+			log.DefaultLogger.Printf("Get containerd auth for %s", config.Server)
+			for _, hostConfig := range config.Hosts {
+				header := strings.TrimPrefix(hostConfig.Header.Authorization, "Basic ")
+				matchedServerHeader = ContainerdServerHeader{
+					Server: config.Server,
+					Header: header,
+				}
+				return nil
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return ContainerdServerHeader{}, err
+	}
+
+	return matchedServerHeader, nil
+}

--- a/pkg/registry/containerd_credentials_test.go
+++ b/pkg/registry/containerd_credentials_test.go
@@ -1,0 +1,55 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pelletier/go-toml"
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistryAuthenticator_GetHeaderOnContainerdFiles(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	// Create test directory and files in the in-memory file system
+	err := fs.MkdirAll("/etc/containerd", 0755)
+	assert.NoError(t, err)
+
+	config := ContainerdConfig{
+		Server: "registry.example.com",
+		Hosts: map[string]ContainerdHostConfig{
+			"example-host": {
+				Capabilities: []string{"cap1", "cap2"},
+				Header: ContainerdHeader{
+					Authorization: "Basic dXNlcjpwYXNz",
+				},
+			},
+		},
+	}
+
+	configData, err := toml.Marshal(config)
+	assert.NoError(t, err)
+
+	err = afero.WriteFile(fs, "/etc/containerd/config.toml", configData, 0644)
+	assert.NoError(t, err)
+
+	authenticator := ContainerDAuthenticator{fs: fs} // Create an instance of the RegistryAuthenticator
+
+	imagePullSecret := ""
+	registry := "registry.example.com"
+	image := "myimage"
+	tag := "latest"
+	candidates := make(chan AuthenticationToken)
+	go authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag, candidates)
+
+	receivedToken, ok := <-candidates
+	assert.True(t, ok, "AuthenticationToken not received")
+
+	expectedToken := AuthenticationToken{
+		Kind:  "Basic",
+		Token: "dXNlcjpwYXNz",
+	}
+
+	assert.Equal(t, expectedToken, receivedToken)
+}

--- a/pkg/registry/docker_credentials.go
+++ b/pkg/registry/docker_credentials.go
@@ -1,0 +1,186 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/adevinta/noe/pkg/log"
+	"github.com/spf13/afero"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type DockerAuths map[string]DockerAuth
+
+type DockerAuth struct {
+	Auth string `json:"auth"`
+}
+
+type DockerConfig struct {
+	Auths      DockerAuths `json:"auths"`
+	CredsStore string      `json:"credsStore"`
+}
+
+type DockerConfigAuthenticator struct {
+	scheme               *runtime.Scheme
+	KubeletAuthenticator Authenticator
+}
+
+func (r DockerConfigAuthenticator) parseDockerConfig(reader io.ReadCloser) (DockerConfig, error) {
+	defer reader.Close()
+	c := DockerConfig{}
+	return c, json.NewDecoder(reader).Decode(&c)
+}
+
+func (r DockerConfigAuthenticator) getAuthCandidates(ctx context.Context, cfg DockerConfig, registry, image string) chan string {
+	candidates := make(chan string)
+	go func() {
+		defer close(candidates)
+		if cfg.CredsStore != "" {
+			if registry == "docker.io" {
+				registry = "index.docker.io"
+			}
+			cmd := exec.Command("docker-credential-"+cfg.CredsStore, "get")
+			cmd.Stdin = strings.NewReader(registry)
+			b := bytes.Buffer{}
+			cmd.Stdout = &b
+			err := cmd.Run()
+			if err != nil {
+				// TODO: log for higher verbosity levels
+			} else {
+				login := map[string]string{}
+				err := json.NewDecoder(&b).Decode(&login)
+				if err != nil {
+					// TODO: log for higher verbosity levels
+				} else {
+					select {
+					case candidates <- base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", login["Username"], login["Secret"]))):
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}
+		for reg, auth := range cfg.Auths {
+			if reg == "https://index.docker.io/v1/" {
+				reg = "docker.io"
+			}
+			// Implement kubernetes lookups: https://kubernetes.io/docs/concepts/containers/images/#config-json
+			// TODO: match does not seem to always work
+			if matched, err := filepath.Match(reg, fmt.Sprintf("%s/%s", registry, image)); err == nil && (matched || reg == registry) {
+				if auth.Auth != "" {
+					log.DefaultLogger.WithContext(ctx).WithField("registry", reg).WithField("image", fmt.Sprintf("%s/%s", registry, image)).Printf("Image matches registry config. Trying it")
+					select {
+					case candidates <- auth.Auth:
+					case <-ctx.Done():
+						return
+					}
+				}
+			}
+		}
+	}()
+	return candidates
+}
+
+func (r DockerConfigAuthenticator) Authenticate(ctx context.Context, cfg DockerConfig, registry, image, tag string, candidates chan AuthenticationToken) {
+	for auth := range r.getAuthCandidates(ctx, cfg, registry, image) {
+		select {
+		case candidates <- AuthenticationToken{
+			Kind:  "Basic",
+			Token: auth,
+		}:
+		case <-ctx.Done():
+			return
+		}
+	}
+	select {
+	case candidates <- AuthenticationToken{}:
+	case <-ctx.Done():
+		return
+	}
+}
+
+type ImagePullSecretAuthenticator struct {
+	DockerConfigAuthenticator
+}
+
+var _ Authenticator = ImagePullSecretAuthenticator{}
+
+func (r ImagePullSecretAuthenticator) Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken) {
+	if imagePullSecret != "" {
+		cfg := DockerConfig{}
+		if err := json.NewDecoder(strings.NewReader(imagePullSecret)).Decode(&cfg); err != nil {
+			log.DefaultLogger.WithContext(ctx).WithError(err).Error("failed to decode imagePullSecret")
+		} else {
+			r.DockerConfigAuthenticator.Authenticate(ctx, cfg, registry, image, tag, candidates)
+		}
+	}
+}
+
+type DockerConfigFileAuthenticator struct {
+	fs afero.Fs
+	DockerConfigAuthenticator
+}
+
+var _ Authenticator = DockerConfigFileAuthenticator{}
+
+func (r DockerConfigFileAuthenticator) readDockerConfig() DockerConfig {
+	// Read more: https://kubernetes.io/docs/concepts/containers/images/#config-json
+	// https://v1-21.docs.kubernetes.io/docs/concepts/containers/images/#configuring-nodes-to-authenticate-to-a-private-registry
+	// and: https://stackoverflow.com/a/65356707
+	candidates := []string{
+		"/var/lib/kubelet/config.json", // TODO: add the kubelet --prefix option
+		// TODO: add {cwd of kubelet}/config.json option
+	}
+	if envVal, ok := os.LookupEnv("DOCKER_CONFIG"); ok {
+		candidates = append(candidates, filepath.Join(envVal, "config.json"))
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".docker/config.json"))
+	}
+	if home, ok := os.LookupEnv("HOME"); ok {
+		candidates = append(candidates, filepath.Join(home, ".docker/config.json"))
+	}
+	candidates = append(candidates,
+		"/.docker/config.json",
+		"/var/lib/kubelet/.dockercfg",
+		// TODO add {--root-dir:-/var/lib/kubelet}/.dockercfg option
+	)
+	if home, err := os.UserHomeDir(); err == nil {
+		candidates = append(candidates, filepath.Join(home, ".dockercfg"))
+	}
+	if home, ok := os.LookupEnv("HOME"); ok {
+		candidates = append(candidates, filepath.Join(home, ".dockercfg"))
+	}
+	candidates = append(candidates, "/.dockercfg")
+	for _, candidate := range candidates {
+		fd, err := r.fs.Open(candidate)
+		if err != nil {
+			// TODO: log for higher verbosity levels
+			continue
+		}
+		cfg, err := r.parseDockerConfig(fd)
+		if err != nil {
+			// TODO: log for higher verbosity levels
+			continue
+		}
+		for registry := range cfg.Auths {
+			log.DefaultLogger.WithField("registry", registry).WithField("candidate", candidate).Debug("loaded registry auth config")
+		}
+		return cfg
+	}
+	return DockerConfig{}
+}
+
+func (r DockerConfigFileAuthenticator) Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken) {
+	cfg := r.readDockerConfig()
+
+	r.DockerConfigAuthenticator.Authenticate(ctx, cfg, registry, image, tag, candidates)
+}

--- a/pkg/registry/docker_credentials.go
+++ b/pkg/registry/docker_credentials.go
@@ -100,11 +100,6 @@ func (r DockerConfigAuthenticator) Authenticate(ctx context.Context, cfg DockerC
 			return
 		}
 	}
-	select {
-	case candidates <- AuthenticationToken{}:
-	case <-ctx.Done():
-		return
-	}
 }
 
 type ImagePullSecretAuthenticator struct {

--- a/pkg/registry/docker_credentials_test.go
+++ b/pkg/registry/docker_credentials_test.go
@@ -1,0 +1,56 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/spf13/afero"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDockerAuthenticatorWithimagePullSecret(t *testing.T) {
+	imagePullSecret := `{"auths":{"registry.example.com":{"username":"user","password":"pass","auth":"YXV0aDp1c2VyOnBhc3M="}}}`
+	registry := "registry.example.com"
+	image := "myimage"
+	tag := "latest"
+
+	authenticator := ImagePullSecretAuthenticator{} // Create an instance of the RegistryAuthenticator
+	candidates := make(chan AuthenticationToken)
+	go authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag, candidates)
+
+	receivedToken, ok := <-candidates
+	assert.True(t, ok, "AuthenticationToken not received")
+
+	expectedToken := AuthenticationToken{
+		Kind:  "Basic",
+		Token: "YXV0aDp1c2VyOnBhc3M=",
+	}
+
+	assert.Equal(t, expectedToken, receivedToken)
+
+}
+
+func TestDockerConfigFileWithimagePullSecret(t *testing.T) {
+	imagePullSecret := `{"auths":{"registry.example.com":{"username":"user","password":"pass","auth":"YXV0aDp1c2VyOnBhc3M="}}}`
+	registry := "registry.example.com"
+	image := "myimage"
+	tag := "latest"
+
+	fs := afero.NewMemMapFs()
+	afero.WriteFile(fs, "/var/lib/kubelet/config.json", []byte(imagePullSecret), 0644)
+
+	authenticator := DockerConfigFileAuthenticator{fs: fs} // Create an instance of the RegistryAuthenticator
+	candidates := make(chan AuthenticationToken)
+	go authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag, candidates)
+
+	receivedToken, ok := <-candidates
+	assert.True(t, ok, "AuthenticationToken not received")
+
+	expectedToken := AuthenticationToken{
+		Kind:  "Basic",
+		Token: "YXV0aDp1c2VyOnBhc3M=",
+	}
+
+	assert.Equal(t, expectedToken, receivedToken)
+
+}

--- a/pkg/registry/login.go
+++ b/pkg/registry/login.go
@@ -37,6 +37,7 @@ func NewAuthenticator() Authenticators {
 		ImagePullSecretAuthenticator{},
 		ContainerDAuthenticator{fs: fs},
 		DockerConfigFileAuthenticator{fs: fs},
+		AnonymousAuthenticator{},
 	}
 	return a
 }

--- a/pkg/registry/login.go
+++ b/pkg/registry/login.go
@@ -31,13 +31,12 @@ func (a Authenticators) Authenticate(ctx context.Context, imagePullSecret, regis
 	}
 }
 
-func NewAuthenticator(kubeletConfigFile, kubeletBinDir string) Authenticators {
+func NewAuthenticator() Authenticators {
 	fs := afero.NewOsFs()
 	a := Authenticators{
 		ImagePullSecretAuthenticator{},
 		ContainerDAuthenticator{fs: fs},
 		DockerConfigFileAuthenticator{fs: fs},
 	}
-
 	return a
 }

--- a/pkg/registry/login.go
+++ b/pkg/registry/login.go
@@ -1,259 +1,43 @@
 package registry
 
 import (
-	"bytes"
 	"context"
-	"encoding/base64"
-	"encoding/json"
-	"fmt"
-	"io"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"regexp"
-	"strings"
 
-	"github.com/adevinta/noe/pkg/log"
-	"github.com/pelletier/go-toml"
 	"github.com/spf13/afero"
 )
-
-type ContainerdHostConfig struct {
-	Capabilities []string         `toml:"capabilities"`
-	Header       ContainerdHeader `toml:"header"`
-}
-
-type ContainerdHeader struct {
-	Authorization string `toml:"authorization"`
-}
-
-type ContainerdConfig struct {
-	Server string                          `toml:"server"`
-	Hosts  map[string]ContainerdHostConfig `toml:"host"`
-}
-
-type DockerAuths map[string]DockerAuth
-
-type DockerAuth struct {
-	Auth string `json:"auth"`
-}
-
-type DockerConfig struct {
-	Auths      DockerAuths `json:"auths"`
-	CredsStore string      `json:"credsStore"`
-}
 
 type AuthenticationToken struct {
 	Kind  string
 	Token string
 }
 
-type ContainerdServerHeader struct {
-	Server string
-	Header string
-}
-
 type Authenticator interface {
 	Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken)
 }
 
-var _ Authenticator = RegistryAuthenticator{}
+type AuthenticatorFunc func(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken)
 
-type RegistryAuthenticator struct {
-	fs afero.Fs
+func (f AuthenticatorFunc) Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken) {
+	f(ctx, imagePullSecret, registry, image, tag, candidates)
 }
 
-func (r RegistryAuthenticator) parseDockerConfig(reader io.ReadCloser) (DockerConfig, error) {
-	defer reader.Close()
-	c := DockerConfig{}
-	return c, json.NewDecoder(reader).Decode(&c)
-}
+var _ Authenticator = Authenticators{}
 
-func (r RegistryAuthenticator) readDockerConfig() DockerConfig {
-	// Read more: https://kubernetes.io/docs/concepts/containers/images/#config-json
-	// https://v1-21.docs.kubernetes.io/docs/concepts/containers/images/#configuring-nodes-to-authenticate-to-a-private-registry
-	// and: https://stackoverflow.com/a/65356707
-	candidates := []string{
-		"/var/lib/kubelet/config.json", // TODO: add the kubelet --prefix option
-		// TODO: add {cwd of kubelet}/config.json option
-	}
-	if envVal, ok := os.LookupEnv("DOCKER_CONFIG"); ok {
-		candidates = append(candidates, filepath.Join(envVal, "config.json"))
-	}
-	if home, err := os.UserHomeDir(); err == nil {
-		candidates = append(candidates, filepath.Join(home, ".docker/config.json"))
-	}
-	if home, ok := os.LookupEnv("HOME"); ok {
-		candidates = append(candidates, filepath.Join(home, ".docker/config.json"))
-	}
-	candidates = append(candidates,
-		"/.docker/config.json",
-		"/var/lib/kubelet/.dockercfg",
-		// TODO add {--root-dir:-/var/lib/kubelet}/.dockercfg option
-	)
-	if home, err := os.UserHomeDir(); err == nil {
-		candidates = append(candidates, filepath.Join(home, ".dockercfg"))
-	}
-	if home, ok := os.LookupEnv("HOME"); ok {
-		candidates = append(candidates, filepath.Join(home, ".dockercfg"))
-	}
-	candidates = append(candidates, "/.dockercfg")
-	for _, candidate := range candidates {
-		fd, err := os.Open(candidate)
-		if err != nil {
-			// TODO: log for higher verbosity levels
-			continue
-		}
-		cfg, err := r.parseDockerConfig(fd)
-		if err != nil {
-			// TODO: log for higher verbosity levels
-			continue
-		}
-		for registry := range cfg.Auths {
-			log.DefaultLogger.WithField("registry", registry).WithField("candidate", candidate).Debug("loaded registry auth config")
-		}
-		return cfg
-	}
-	return DockerConfig{}
-}
+type Authenticators []Authenticator
 
-func (r RegistryAuthenticator) getHeaderOnContainerdFiles(repository, directory string) (ContainerdServerHeader, error) {
-	var matchedServerHeader ContainerdServerHeader
-
-	err := afero.Walk(r.fs, directory, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil
-		}
-
-		if info.IsDir() {
-			return nil
-		}
-
-		fileExtension := filepath.Ext(path)
-		if fileExtension != ".toml" {
-			return nil
-		}
-
-		configData, err := afero.ReadFile(r.fs, path)
-		if err != nil {
-			return nil
-		}
-
-		config := ContainerdConfig{}
-		err = toml.Unmarshal(configData, &config)
-		if err != nil {
-			return nil
-		}
-
-		if match, _ := regexp.MatchString(repository, config.Server); match {
-			log.DefaultLogger.Printf("Get containerd auth for %s", config.Server)
-			for _, hostConfig := range config.Hosts {
-				header := strings.TrimPrefix(hostConfig.Header.Authorization, "Basic ")
-				matchedServerHeader = ContainerdServerHeader{
-					Server: config.Server,
-					Header: header,
-				}
-				return nil
-			}
-		}
-
-		return nil
-	})
-
-	if err != nil {
-		return ContainerdServerHeader{}, err
-	}
-
-	return matchedServerHeader, nil
-}
-
-func (r RegistryAuthenticator) getAuthCandidates(ctx context.Context, cfg DockerConfig, registry, image string) chan string {
-	candidates := make(chan string)
-	go func() {
-		defer close(candidates)
-		if cfg.CredsStore != "" {
-			if registry == "docker.io" {
-				registry = "index.docker.io"
-			}
-			cmd := exec.Command("docker-credential-"+cfg.CredsStore, "get")
-			cmd.Stdin = strings.NewReader(registry)
-			b := bytes.Buffer{}
-			cmd.Stdout = &b
-			err := cmd.Run()
-			if err != nil {
-				// TODO: log for higher verbosity levels
-			} else {
-				login := map[string]string{}
-				err := json.NewDecoder(&b).Decode(&login)
-				if err != nil {
-					// TODO: log for higher verbosity levels
-				} else {
-					select {
-					case candidates <- base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", login["Username"], login["Secret"]))):
-					case <-ctx.Done():
-						return
-					}
-				}
-			}
-		}
-		for reg, auth := range cfg.Auths {
-			if reg == "https://index.docker.io/v1/" {
-				reg = "docker.io"
-			}
-			// Implement kubernetes lookups: https://kubernetes.io/docs/concepts/containers/images/#config-json
-			// TODO: match does not seem to always work
-			if matched, err := filepath.Match(reg, fmt.Sprintf("%s/%s", registry, image)); err == nil && (matched || reg == registry) {
-				if auth.Auth != "" {
-					log.DefaultLogger.WithContext(ctx).WithField("registry", reg).WithField("image", fmt.Sprintf("%s/%s", registry, image)).Printf("Image matches registry config. Trying it")
-					select {
-					case candidates <- auth.Auth:
-					case <-ctx.Done():
-						return
-					}
-				}
-			}
-		}
-		containerdAuth, _ := r.getHeaderOnContainerdFiles(registry, "/etc/containerd")
-		if containerdAuth.Header != "" {
-			log.DefaultLogger.WithContext(ctx).WithField("registry", containerdAuth.Server).WithField("image", fmt.Sprintf("%s/%s", registry, image)).Printf("Image matches registry config. Trying it")
-			select {
-			case candidates <- containerdAuth.Header:
-			case <-ctx.Done():
-				return
-			}
-		}
-
-	}()
-	return candidates
-}
-
-func (r RegistryAuthenticator) tryAllCandidates(ctx context.Context, cfg DockerConfig, registry, image, tag string, candidates chan AuthenticationToken) {
-	for auth := range r.getAuthCandidates(ctx, cfg, registry, image) {
-		select {
-		case candidates <- AuthenticationToken{
-			Kind:  "Basic",
-			Token: auth,
-		}:
-		case <-ctx.Done():
-			return
-		}
-	}
-	select {
-	case candidates <- AuthenticationToken{}:
-	case <-ctx.Done():
-		return
+func (a Authenticators) Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken) {
+	for _, auth := range a {
+		auth.Authenticate(ctx, imagePullSecret, registry, image, tag, candidates)
 	}
 }
 
-func (r RegistryAuthenticator) Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken) {
-	cfg := r.readDockerConfig()
-	if imagePullSecret != "" {
-		imagePullSecretConfig := DockerConfig{}
-		if err := json.NewDecoder(strings.NewReader(imagePullSecret)).Decode(&imagePullSecretConfig); err != nil {
-			// TODO: log
-		} else {
-			r.tryAllCandidates(ctx, imagePullSecretConfig, registry, image, tag, candidates)
-		}
+func NewAuthenticator(kubeletConfigFile, kubeletBinDir string) Authenticators {
+	fs := afero.NewOsFs()
+	a := Authenticators{
+		ImagePullSecretAuthenticator{},
+		ContainerDAuthenticator{fs: fs},
+		DockerConfigFileAuthenticator{fs: fs},
 	}
-	r.tryAllCandidates(ctx, cfg, registry, image, tag, candidates)
+
+	return a
 }

--- a/pkg/registry/login_test.go
+++ b/pkg/registry/login_test.go
@@ -1,79 +1,9 @@
 package registry
 
 import (
-	"context"
 	"testing"
-
-	"github.com/pelletier/go-toml"
-	"github.com/spf13/afero"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAuthenticateWithimagePullSecret(t *testing.T) {
-	imagePullSecret := `{"auths":{"registry.example.com":{"username":"user","password":"pass","auth":"YXV0aDp1c2VyOnBhc3M="}}}`
-	registry := "registry.example.com"
-	image := "myimage"
-	tag := "latest"
 
-	authenticator := RegistryAuthenticator{fs: afero.NewMemMapFs()} // Create an instance of the RegistryAuthenticator
-
-	candidates := make(chan AuthenticationToken)
-	go authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag, candidates)
-
-	receivedToken, ok := <-candidates
-	assert.True(t, ok, "AuthenticationToken not received")
-
-	expectedToken := AuthenticationToken{
-		Kind:  "Basic",
-		Token: "YXV0aDp1c2VyOnBhc3M=",
-	}
-
-	assert.Equal(t, expectedToken, receivedToken)
-
-}
-
-func TestRegistryAuthenticator_GetHeaderOnContainerdFiles(t *testing.T) {
-	fs := afero.NewMemMapFs()
-
-	// Create test directory and files in the in-memory file system
-	err := fs.MkdirAll("/etc/containerd", 0755)
-	assert.NoError(t, err)
-
-	config := ContainerdConfig{
-		Server: "registry.example.com",
-		Hosts: map[string]ContainerdHostConfig{
-			"example-host": {
-				Capabilities: []string{"cap1", "cap2"},
-				Header: ContainerdHeader{
-					Authorization: "Basic dXNlcjpwYXNz",
-				},
-			},
-		},
-	}
-
-	configData, err := toml.Marshal(config)
-	assert.NoError(t, err)
-
-	err = afero.WriteFile(fs, "/etc/containerd/config.toml", configData, 0644)
-	assert.NoError(t, err)
-
-	authenticator := RegistryAuthenticator{fs: fs} // Create an instance of the RegistryAuthenticator
-
-	imagePullSecret := ""
-	registry := "registry.example.com"
-	image := "myimage"
-	tag := "latest"
-
-	candidates := make(chan AuthenticationToken)
-	go authenticator.Authenticate(context.Background(), imagePullSecret, registry, image, tag, candidates)
-
-	receivedToken, ok := <-candidates
-	assert.True(t, ok, "AuthenticationToken not received")
-
-	expectedToken := AuthenticationToken{
-		Kind:  "Basic",
-		Token: "dXNlcjpwYXNz",
-	}
-
-	assert.Equal(t, expectedToken, receivedToken)
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -27,7 +27,7 @@ var DefaultRegistry = NewPlainRegistry()
 func NewPlainRegistry(builders ...func(*PlainRegistry)) PlainRegistry {
 	r := PlainRegistry{
 		Scheme:        "https",
-		Authenticator: NewAuthenticator("", ""),
+		Authenticator: NewAuthenticator(),
 		Proxies:       []RegistryProxy{},
 	}
 	for _, builder := range builders {
@@ -93,7 +93,6 @@ func WithAuthenticator(authenticator Authenticator) func(*PlainRegistry) {
 	return func(r *PlainRegistry) {
 		r.Authenticator = authenticator
 	}
-
 }
 
 func (r PlainRegistry) parseImage(image string) (string, string, string, bool) {

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -15,7 +15,7 @@ import (
 	"github.com/adevinta/noe/pkg/httputils"
 	"github.com/adevinta/noe/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/spf13/afero"
+	"github.com/sirupsen/logrus"
 )
 
 type Registry interface {
@@ -27,7 +27,7 @@ var DefaultRegistry = NewPlainRegistry()
 func NewPlainRegistry(builders ...func(*PlainRegistry)) PlainRegistry {
 	r := PlainRegistry{
 		Scheme:        "https",
-		Authenticator: RegistryAuthenticator{fs: afero.NewOsFs()},
+		Authenticator: NewAuthenticator("", ""),
 		Proxies:       []RegistryProxy{},
 	}
 	for _, builder := range builders {
@@ -87,6 +87,13 @@ func WithDockerProxies(proxies []RegistryProxy) func(*PlainRegistry) {
 	return func(r *PlainRegistry) {
 		r.Proxies = append(r.Proxies, proxies...)
 	}
+}
+
+func WithAuthenticator(authenticator Authenticator) func(*PlainRegistry) {
+	return func(r *PlainRegistry) {
+		r.Authenticator = authenticator
+	}
+
 }
 
 func (r PlainRegistry) parseImage(image string) (string, string, string, bool) {
@@ -303,6 +310,7 @@ func (r PlainRegistry) listArchsWithAuth(ctx context.Context, client http.Client
 }
 
 func (r PlainRegistry) ListArchs(ctx context.Context, imagePullSecret, image string) ([]Platform, error) {
+	ctx = log.AddLogFieldsToContext(ctx, logrus.Fields{"image": image})
 	transport := http.DefaultTransport
 	if r.Transport != nil {
 		transport = r.Transport


### PR DESCRIPTION
Context
---

We currently suport 2 authentication sources. Docker and containerD.

Problems
---

1. Kubelet has a third one: [CredentialProviderConfig]

To be consistent, noe needs to implement all of those to be able to
lookup the values in the relevant place.

2. The current containerD authentication is mixed with the Docker one (file
and image pull secret ones).

Goal
---

Get clearer isolation between the different authentication mechanisms
Ease implementing new authentication methods

[CredentialProviderConfig]: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Refactor main entrypoint (#89)
</summary>

</details>
<details>
<summary>
Bump controller-runtime version (#91)
</summary>

</details>
<details>
<summary>
Implement kubelet CredentialProvider (#90)
</summary>
Context
---

We currently suport 2 authentication sources. Docker and containerD.

Problems
---

1. Kubelet has a third one: [CredentialProviderConfig]

To be consistent, noe needs to implement all of those to be able to
lookup the values in the relevant place.

2. The current containerD authentication is mixed with the Docker one (file
and image pull secret ones).

Goal
---

Add supoort for kubelet CredentialProvider

[CredentialProviderConfig]: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
</details>
</details>
</details>