### PR TITLE
Refactor main entrypoint

### DIFF
--- a/cmd/noe/main_test.go
+++ b/cmd/noe/main_test.go
@@ -105,7 +105,9 @@ func TestNoeMain(t *testing.T) {
 	require.NoError(t, err)
 	os.Setenv("KUBECONFIG", env.KubeconfigFile())
 
-	go Main(ctx, "./integration-tests/", "amd64", "", "linux", ":8181", "", "")
+	os.Args = []string{"noe", "--cert-dir", "./integration-tests/", "--metrics-addr", ":8181", "--preferred-arch", "amd64"}
+	mainContext = ctx
+	go main()
 
 	client := http.Client{
 		Transport: &http.Transport{


### PR DESCRIPTION

<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Bump controller-runtime version (#91)
</summary>

</details>
<details>
<summary>
Implement kubelet CredentialProvider (#90)
</summary>
Context
---

We currently suport 2 authentication sources. Docker and containerD.

Problems
---

1. Kubelet has a third one: [CredentialProviderConfig]

To be consistent, noe needs to implement all of those to be able to
lookup the values in the relevant place.

2. The current containerD authentication is mixed with the Docker one (file
and image pull secret ones).

Goal
---

Add supoort for kubelet CredentialProvider

[CredentialProviderConfig]: https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/
</details>
</details>
</details>