### PR TITLE
Modify noe status

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -283,9 +283,12 @@ func (r PlainRegistry) listArchsWithAuth(ctx context.Context, client http.Client
 				// In any case, these will be managed as "defaults"
 				if manifest.Platform.Architecture == "unknown" {
 					log.DefaultLogger.WithContext(ctx).Printf("skipping %s%s:%s since it contains an unknown supported platform.\n", manifest.Platform.Architecture, registry, image)
-					return nil, fmt.Errorf("unknown architecture in manifest for %s/%s", registry, image)
+					continue
 				}
 				platforms = append(platforms, manifest.Platform)
+			} else if resp.StatusCode == http.StatusNotFound {
+				log.DefaultLogger.WithContext(ctx).Printf("skipping %s%s:%s since it can't be fetched. StatusCode: %d\n", manifest.Platform.Architecture, registry, image, resp.StatusCode)
+				continue
 			} else {
 				log.DefaultLogger.WithContext(ctx).Printf("failed to get pointed manifest for arch %s of %s/%s: statusCode: %d. Skipping\n", manifest.Platform.Architecture, registry, image, resp.StatusCode)
 				return nil, fmt.Errorf("failed to get pointed manifest for %s/%s: statusCode: %d", registry, image, resp.StatusCode)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -275,7 +275,7 @@ func (r PlainRegistry) listArchsWithAuth(ctx context.Context, client http.Client
 			)
 			if err != nil {
 				log.DefaultLogger.WithContext(ctx).Printf("failed to get pointed manifest for arch %s of %s/%s: %v. Skipping\n", manifest.Platform.Architecture, registry, image, err)
-				continue
+				return nil, err
 			}
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -283,11 +283,12 @@ func (r PlainRegistry) listArchsWithAuth(ctx context.Context, client http.Client
 				// In any case, these will be managed as "defaults"
 				if manifest.Platform.Architecture == "unknown" {
 					log.DefaultLogger.WithContext(ctx).Printf("skipping %s%s:%s since it contains an unknown supported platform.\n", manifest.Platform.Architecture, registry, image)
-					continue
+					return nil, fmt.Errorf("unknown architecture in manifest for %s/%s", registry, image)
 				}
 				platforms = append(platforms, manifest.Platform)
 			} else {
 				log.DefaultLogger.WithContext(ctx).Printf("failed to get pointed manifest for arch %s of %s/%s: statusCode: %d. Skipping\n", manifest.Platform.Architecture, registry, image, resp.StatusCode)
+				return nil, fmt.Errorf("failed to get pointed manifest for %s/%s: statusCode: %d", registry, image, resp.StatusCode)
 			}
 		}
 	default:


### PR DESCRIPTION
Context
---
change the noe behaviour with the status of fetching the images, as per https://github.com/adevinta/noe/pull/84, When retrieving image distribution manifest list, we send the request without any Accept header. and this causes some image registries to return 404, and makes us miss the real image architectures supported.

Problem
---

When there is a network error (i.e. failing to execute the HTTP request line [278](https://github.com/adevinta/noe/pull/92/files#diff-cb61d8f79451b9541de4a8cc0811523a68d15452b2f5971c7618ea5b423cf4ecR278))  there is a problem with the registry, hence faill hard
When the registry returns 404 for a specific image manifest (line [290](https://github.com/adevinta/noe/pull/92/files#diff-cb61d8f79451b9541de4a8cc0811523a68d15452b2f5971c7618ea5b423cf4ecR290)), the request succeeded but the registry does not know about the manifest. Probably an incomplete mirror, or failed upload. It's likely that kubelet or the container runtime would also fail to pull the image, exclude the architecture
Any other error (401, 403, 5xx) is likely to be a configuration error (credentials or server error), hence fail hard to report the error


Goal
---

return error in case failure of fetching images in specific cases