### PR TITLE
Extract cache logic from the cache registry

### DIFF
--- a/pkg/registry/cache.go
+++ b/pkg/registry/cache.go
@@ -2,12 +2,104 @@ package registry
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
+	"github.com/adevinta/noe/pkg/log"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
+
+type CacheEntry[T any] struct {
+	Value  *T
+	Expiry time.Time
+}
+
+type Cache[T any] struct {
+	cache         sync.Map
+	serialize     sync.Map
+	cleanupAccess sync.Mutex
+	lastCleanup   time.Time
+	CleanUpPeriod time.Duration
+	CacheDuration time.Duration
+}
+
+func NewCache[T any](cacheDuration time.Duration) *Cache[T] {
+	return &Cache[T]{
+		CacheDuration: cacheDuration,
+	}
+}
+
+func (c *Cache[T]) Load(cacheKey string) (*T, bool) {
+	if entry, ok := c.cache.Load(cacheKey); ok {
+		cached := entry.(*CacheEntry[T])
+		if time.Now().Before(cached.Expiry) {
+			return cached.Value, true
+		}
+	}
+	return nil, false
+}
+
+func (c *Cache[T]) LoadOrCall(cacheKey string, miss func() (T, error)) (T, bool, error) {
+	cond, _ := c.serialize.LoadOrStore(cacheKey, &sync.Mutex{})
+	serialize := cond.(*sync.Mutex)
+
+	// Serialize requests for the same key
+	serialize.Lock()
+	defer serialize.Unlock()
+
+	if entry, ok := c.Load(cacheKey); ok {
+		return *entry, true, nil
+	}
+
+	value, err := miss()
+	if err != nil {
+		return value, false, err
+	}
+	c.Store(cacheKey, &value)
+	return value, false, nil
+}
+
+func (c *Cache[T]) Store(cacheKey string, value *T, mutations ...func(*CacheEntry[T])) {
+	entry := &CacheEntry[T]{
+		Value:  value,
+		Expiry: time.Now().Add(c.CacheDuration),
+	}
+	for _, mutation := range mutations {
+		mutation(entry)
+	}
+	c.cache.Store(cacheKey, entry)
+}
+
+func (c *Cache[T]) CleanUp(now time.Time) {
+	c.cleanupAccess.Lock()
+	defer c.cleanupAccess.Unlock()
+	if c.CleanUpPeriod == 0 {
+		log.DefaultLogger.Debug("setting default cleanup period to 5 minutes")
+		c.CleanUpPeriod = 5 * time.Minute
+	}
+	if now.Before(c.lastCleanup.Add(c.CleanUpPeriod)) {
+		log.DefaultLogger.WithField("cleanupPeriod", c.CleanUpPeriod).Debug("Not enough time passed since last cleanup, skipping")
+		return
+	}
+	c.cache.Range(func(key, value interface{}) bool {
+		entry := value.(*CacheEntry[T])
+		if now.After(entry.Expiry) {
+			log.DefaultLogger.WithField("key", key).WithField("expire", entry.Expiry).Debug("cleaning up expired cache entry")
+			c.cache.Delete(key)
+			c.serialize.Delete(key)
+		}
+		return true
+	})
+	c.lastCleanup = now
+}
+
+func (c *Cache[T]) WithExpiry(expiry time.Time) func(*CacheEntry[T]) {
+	return func(entry *CacheEntry[T]) {
+		entry.Expiry = expiry
+	}
+}
 
 type CacheMetrics struct {
 	Requests  *prometheus.CounterVec
@@ -21,46 +113,37 @@ func (m CacheMetrics) MustRegister(reg metrics.RegistererGatherer) {
 	)
 }
 
-func NewCacheMetrics(prefix string) *CacheMetrics {
+func NewCacheMetrics(prefix, system string) *CacheMetrics {
 	m := &CacheMetrics{
 		Requests: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: prefix,
-			Subsystem: "registry_cache",
-			Name:      "requests_total",
-			Help:      "Number of requests to the registry cache",
+			Subsystem: system,
+			Name:      "cache_requests_total",
+			Help:      fmt.Sprintf("Number of requests to the %s cache", system),
 		}, []string{}),
 		Responses: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: prefix,
-			Subsystem: "registry_cache",
-			Name:      "responses_total",
-			Help:      "Number of request responses from the registry cache",
+			Subsystem: system,
+			Name:      "cache_responses_total",
+			Help:      fmt.Sprintf("Number of request responses from the %s cache", system),
 		}, []string{"cache"}),
 	}
 	return m
 }
 
-type cacheEntry struct {
-	platforms []Platform
-	expiry    time.Time
-}
-
 type CacheOption func(*CachedRegistry)
 type CachedRegistry struct {
-	registry      Registry
-	cache         sync.Map
-	serialize     sync.Map
-	cacheDuration time.Duration
-	cleanupAccess sync.Mutex
-	lastCleanup   time.Time
-	metrics       *CacheMetrics
+	cache    Cache[[]Platform]
+	registry Registry
+	metrics  *CacheMetrics
 }
 
 func NewCachedRegistry(registry Registry, cacheDuration time.Duration, opts ...CacheOption) *CachedRegistry {
 	r := &CachedRegistry{
-		registry:      registry,
-		cacheDuration: cacheDuration,
-		metrics:       NewCacheMetrics("noe"),
+		registry: registry,
+		metrics:  NewCacheMetrics("noe", "registry"),
 	}
+	r.cache.CacheDuration = cacheDuration
 	for _, opt := range opts {
 		opt(r)
 	}
@@ -77,51 +160,25 @@ func (cr *CachedRegistry) ListArchs(ctx context.Context, imagePullSecret, image 
 	cr.metrics.Requests.WithLabelValues().Inc()
 	cacheKey := imagePullSecret + ":" + image
 
-	// Trigger cleanup asynchronously
-	defer func() { go cr.cleanUpCache(time.Now()) }()
-	cond, _ := cr.serialize.LoadOrStore(cacheKey, &sync.Mutex{})
-	serialize := cond.(*sync.Mutex)
+	// Trigger a cleanup of the cache, but don't wait for it to finish
+	// Waiting for the cleanup to finish would block the request and
+	// slow down the response time.
+	defer func() { go cr.cache.CleanUp(time.Now()) }()
 
-	// Serialize requests for the same key
-	serialize.Lock()
-	defer serialize.Unlock()
-
-	// Check cache
-	if entry, ok := cr.cache.Load(cacheKey); ok {
-		cached := entry.(*cacheEntry)
-		if time.Now().Before(cached.expiry) {
-			cr.metrics.Responses.WithLabelValues("hit").Inc()
-			return cached.platforms, nil
+	archs, cached, err := cr.cache.LoadOrCall(cacheKey, func() ([]Platform, error) {
+		archs, err := cr.registry.ListArchs(ctx, imagePullSecret, image)
+		if err != nil {
+			return nil, err
 		}
+		return archs, nil
+	})
+	if err != nil {
+		return nil, err
 	}
-
-	// Fetch from registry and store in cache
-	archs, err := cr.registry.ListArchs(ctx, imagePullSecret, image)
-	if err == nil {
-		entry := &cacheEntry{
-			platforms: archs,
-			expiry:    time.Now().Add(cr.cacheDuration),
-		}
-		cr.cache.Store(cacheKey, entry)
+	if cached {
+		cr.metrics.Responses.WithLabelValues("hit").Inc()
+	} else {
 		cr.metrics.Responses.WithLabelValues("miss").Inc()
 	}
-
-	return archs, err
-}
-
-func (cr *CachedRegistry) cleanUpCache(now time.Time) {
-	cr.cleanupAccess.Lock()
-	defer cr.cleanupAccess.Unlock()
-	if now.Before(cr.lastCleanup.Add(5 * time.Minute)) {
-		return
-	}
-	cr.cache.Range(func(key, value interface{}) bool {
-		entry := value.(*cacheEntry)
-		if now.After(entry.expiry) {
-			cr.cache.Delete(key)
-			cr.serialize.Delete(key)
-		}
-		return true
-	})
-	cr.lastCleanup = now
+	return archs, nil
 }


### PR DESCRIPTION
Context
---

We are observing an important number of 429 (too many requests) do
Dockerhub.

This is due to the fact that we authenticate to DockerHub for each
request of each manifest.

In some cases, images are built for many architectures, like the alpine one
which is built for 7 architectures.

This plays against the [DockerHub rate limits](https://www.docker.com/increase-rate-limits/)
and consume too much of those (from a 100 to 5k pulls per day depending
on the users)

Goal
---

Refactor the code so the cache is easily re-usable for the
authentication mechanisms
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add cache to the www-authenticate roundtripper (#99)
</summary>
Context
---

We are observing an important number of 429 (too many requests) do
Dockerhub.

This is due to the fact that we authenticate to DockerHub for each
request of each manifest.

In some cases, images are built for many architectures, like the alpine one
which is built for 7 architectures.

This plays against the [DockerHub rate limits](https://www.docker.com/increase-rate-limits/)
and consume too much of those (from a 100 to 5k pulls per day depending
on the users)

Goal
---

Reduce the number of authentication to DockerHub as much as possible
</details>
<details>
<summary>
Add metrics to the registry client (#100)
</summary>
Allow monitoring the rate of image registry accesses and errors
</details>
</details>
</details>