### PR TITLE
Add cache to the www-authenticate roundtripper

### DIFF
--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -81,6 +81,7 @@ func main() {
 			},
 			registry.RegistryLabeller,
 		)),
+		registry.WithRegistryMetricRegistry(metrics.Registry),
 	)
 	containerRegistry = registry.NewCachedRegistry(containerRegistry, 1*time.Hour, registry.WithCacheMetricsRegistry(metrics.Registry))
 


### PR DESCRIPTION
Context
---

We are observing an important number of 429 (too many requests) do
Dockerhub.

This is due to the fact that we authenticate to DockerHub for each
request of each manifest.

In some cases, images are built for many architectures, like the alpine one
which is built for 7 architectures.

This plays against the [DockerHub rate limits](https://www.docker.com/increase-rate-limits/)
and consume too much of those (from a 100 to 5k pulls per day depending
on the users)

Goal
---

Reduce the number of authentication to DockerHub as much as possible
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>
<details>
<summary>
Related changes
</summary>
<details>
<summary>
Future changes
</summary>
<details>
<summary>
Add metrics to the registry client (#100)
</summary>
Allow monitoring the rate of image registry accesses and errors
</details>
</details>
</details>