### PR TITLE
Fix parseImage function to correctly set registries

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -203,7 +203,7 @@ func (r *PlainRegistry) parseImage(image string) (string, string, string, bool) 
 		image = "library/" + image
 	}
 	for _, proxy := range r.Proxies {
-		if ok, err := filepath.Match("*"+proxy.Registry, registry); err == nil && ok {
+		if ok, err := filepath.Match("*."+proxy.Registry, registry); err == nil && ok {
 			log.DefaultLogger.WithField("registry", registry).WithField("proxy", proxy.Proxy).Debug("using docker registry proxy")
 			registry = proxy.Proxy
 			break

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -203,9 +203,10 @@ func (r *PlainRegistry) parseImage(image string) (string, string, string, bool) 
 		image = "library/" + image
 	}
 	for _, proxy := range r.Proxies {
-		if ok, err := filepath.Match(proxy.Registry, registry); err == nil && ok {
+		if ok, err := filepath.Match("*"+proxy.Registry, registry); err == nil && ok {
 			log.DefaultLogger.WithField("registry", registry).WithField("proxy", proxy.Proxy).Debug("using docker registry proxy")
 			registry = proxy.Proxy
+			break
 		}
 	}
 	return registry, image, tag, hasRef

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -129,8 +129,8 @@ func TestParseImageSubstituteRegistries(t *testing.T) {
 	}
 	registryMatchProxy, _, _, _ := reg.parseImage("registry-1.docker.io/nginxinc/nginx-unprivileged")
 	assert.Equal(t, "other.docker.proxy.tld", registryMatchProxy)
-	registryNotMatchProxy, _, _, _ := reg.parseImage("dockerhub.mpi-internal.com/nginx")
-	assert.Equal(t, "dockerhub.mpi-internal.com", registryNotMatchProxy)
+	registryNotMatchProxy, _, _, _ := reg.parseImage("custom.registry.com/nginx")
+	assert.Equal(t, "custom.registry.com", registryNotMatchProxy)
 	plainImage, _, _, _ := reg.parseImage("ubuntu")
 	assert.Equal(t, "other.docker.proxy.tld", plainImage)
 

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -122,13 +122,18 @@ func TestParseImageSubstituteRegistries(t *testing.T) {
 				Proxy:    "other.docker.proxy.tld",
 			},
 			{
-				Registry: "other.docker.proxy.tld",
+				Registry: "other.docker.proxy.io",
 				Proxy:    "docker.proxy.tld",
 			},
 		},
 	}
-	registry, _, _, _ := reg.parseImage("ubuntu")
-	assert.Equal(t, "docker.proxy.tld", registry)
+	registryMatchProxy, _, _, _ := reg.parseImage("registry-1.docker.io/nginxinc/nginx-unprivileged")
+	assert.Equal(t, "other.docker.proxy.tld", registryMatchProxy)
+	registryNotMatchProxy, _, _, _ := reg.parseImage("dockerhub.mpi-internal.com/nginx")
+	assert.Equal(t, "dockerhub.mpi-internal.com", registryNotMatchProxy)
+	plainImage, _, _, _ := reg.parseImage("ubuntu")
+	assert.Equal(t, "other.docker.proxy.tld", plainImage)
+
 }
 
 func TestListDockerHubLibraryArch(t *testing.T) {


### PR DESCRIPTION
  # Context:
  We detected that proxies were not correctly been used by `noe`. We
  found some issues in the `parseImage` function:
  - the registry had to literally match so if you had a proxy set for `docker.io` registry if it used `something.docker.io` it would not replace with the proxy.
  - It did not stop after finding the relevant proxy, this lead to tests correctly passing without showing issues.

  # What does this PR?
  - Add regex so it matches all subdomains of proxy registry domain.
  - Stops looking for proxies once it finds one.
  - Fix the relevant tests so it tests more cases.
