### PR TITLE
Change behaviour when one of the containers image can not be inspected

### DIFF
--- a/pkg/arch/hook.go
+++ b/pkg/arch/hook.go
@@ -326,8 +326,8 @@ func (h *Handler) updatePodSpec(ctx context.Context, namespace string, podLabels
 		platforms, err := h.Registry.ListArchs(ctx, imagePullSecret, image)
 		if err != nil {
 			h.metrics.RegistryErrors.WithLabelValues(image).Inc()
-			log.DefaultLogger.WithContext(ctx).WithError(err).Printf("unable to list image archs")
-			return nil
+			log.DefaultLogger.WithContext(ctx).WithError(err).WithField("image", image).Printf("unable to list archs for image")
+			continue
 		}
 
 		imageArchitectures := map[string]struct{}{}


### PR DESCRIPTION
  # Context:
  We found out that can happen that a pod has multiple images and for
  some reason we can not get the archs of one of them, currently this
  will make noe not inject any selector which makes the pod able to
  schedule in every node of the cluster, this makes the probability of
  scheduling in the right node equal the number of differnt archs in the
  cluster (1/N, N being the number of different archs in the cluster)
  considering we have the same number of nodes of the same arch.

  In this PR we want to change the approach to instead of not adding any
  selector, add the selector that matches the other images that it could
  list the archs. Now the probablity of scheduling in the right node
  won't depend on the number of different archs in the cluster but the
  probability that the images in the container that could be inspected
  do not match the one that couldn't. This will always be better than
  the previous approach the reason is:
  - Worst case scenario is that we have only 2 images and 1 of them
    could not be listed, in that case the probability of this arch
    being the right one for the pod we can approximate it also as
    1/N, N being the number of different archs supported in the
    cluster.
  - But in cases of having more than 2 images it's more probable
     that if one fails the other 2 common arch also matches the 3rd
     one .

This has a lot of ifs because also depends on the number of nodes that the cluster has for each arch, which may change the most suited approach.
  # What does this PR?
  - Make the seacrch of common architectures between images continue if one of them fails.

Change-Id: I887c13457b3d7e60abd800964b17af890ed08cac