### PR TITLE
Fix webhook flags missing `--`

### DIFF
--- a/charts/noe/templates/webhook.yaml
+++ b/charts/noe/templates/webhook.yaml
@@ -54,8 +54,8 @@ spec:
         imagePullPolicy: Always
         workingDir: /workdir
         args:
-        - registry-proxies={{ .Values.proxies | join "," }}
-        - cluster-schedulable-archs={{ .Values.schedulableArchitectures | join "," }}
+        - --registry-proxies={{ .Values.proxies | join "," }}
+        - --cluster-schedulable-archs={{ .Values.schedulableArchitectures | join "," }}
         ports:
         - containerPort: 8443
           name: webhook


### PR DESCRIPTION
Flags are not used correctly in the deployment manifest in `webhook.yaml`.

# What does this PR?
- Add `--` prefix to arguments in webhook deployment.

