### PR TITLE
Improve webhook latency

### DIFF
--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -82,6 +82,7 @@ func main() {
 			registry.RegistryLabeller,
 		)),
 		registry.WithRegistryMetricRegistry(metrics.Registry),
+		registry.WithSchedulableArchitectures(schedulableArchSlice),
 	)
 	containerRegistry = registry.NewCachedRegistry(containerRegistry, 1*time.Hour, registry.WithCacheMetricsRegistry(metrics.Registry))
 

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,8 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/afero v1.9.5
 	github.com/stretchr/testify v1.8.4
-	golang.org/x/mod v0.12.0
+	golang.org/x/mod v0.14.0
+	golang.org/x/tools v0.16.1
 	gomodules.xyz/jsonpatch/v2 v2.4.0
 	k8s.io/api v0.29.0
 	k8s.io/apimachinery v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -365,6 +365,8 @@ golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
 golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/mod v0.12.0 h1:rmsUpXtvNzj340zd98LZ4KntptpfRHwpFOHG188oHXc=
 golang.org/x/mod v0.12.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -542,6 +544,8 @@ golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/tools v0.7.0 h1:W4OVu8VVOaIO0yzWMNdepAulS7YfoS3Zabrm8DOXXU4=
+golang.org/x/tools v0.16.1 h1:TLyB3WofjdOEepBHAU20JdNC1Zbg87elYofWYAY5oZA=
+golang.org/x/tools v0.16.1/go.mod h1:kYVVN6I1mBNoB1OX+noeBjbRk4IUEPa7JJ+TJMEooJ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/pkg/arch/hook.go
+++ b/pkg/arch/hook.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/adevinta/noe/pkg/log"
@@ -319,19 +320,41 @@ func (h *Handler) updatePodSpec(ctx context.Context, namespace string, podLabels
 	if err != nil {
 		h.metrics.ImagePullSecretFailed.WithLabelValues(namespace).Inc()
 	}
-	firstImage := true
+	imagePlatforms := make(chan struct {
+		image     string
+		platforms []registry.Platform
+	})
+	wg := sync.WaitGroup{}
 	for _, image := range GetContainerImages(podSpec.Containers, podSpec.InitContainers) {
-		ctx := log.AddLogFieldsToContext(ctx, logrus.Fields{"image": image})
-
-		platforms, err := h.Registry.ListArchs(ctx, imagePullSecret, image)
-		if err != nil {
-			h.metrics.RegistryErrors.WithLabelValues(image).Inc()
-			log.DefaultLogger.WithContext(ctx).WithError(err).WithField("image", image).Printf("unable to list archs for image")
-			continue
-		}
+		wg.Add(1)
+		go func(ctx context.Context, image string) {
+			defer wg.Done()
+			ctx = log.AddLogFieldsToContext(ctx, logrus.Fields{"image": image})
+			platforms, err := h.Registry.ListArchs(ctx, imagePullSecret, image)
+			if err != nil {
+				h.metrics.RegistryErrors.WithLabelValues(image).Inc()
+				log.DefaultLogger.WithContext(ctx).WithError(err).Printf("unable to list image archs")
+				return
+			}
+			imagePlatforms <- struct {
+				image     string
+				platforms []registry.Platform
+			}{
+				image:     image,
+				platforms: platforms,
+			}
+		}(ctx, image)
+	}
+	go func() {
+		wg.Wait()
+		close(imagePlatforms)
+	}()
+	firstImage := true
+	for imagePlatform := range imagePlatforms {
+		ctx := log.AddLogFieldsToContext(ctx, logrus.Fields{"image": imagePlatform.image})
 
 		imageArchitectures := map[string]struct{}{}
-		for _, platform := range platforms {
+		for _, platform := range imagePlatform.platforms {
 			if platform.OS != "" && platform.OS != h.systemOS {
 				log.DefaultLogger.WithContext(ctx).WithField("os", platform.OS).Info("Skipped OS does not match system's")
 				continue


### PR DESCRIPTION
Problem
---

Currently, we are doing all image inspection in serial.

This causes the overall webhook latency to sum the time to list
schedulable architectures of all images.

Listing image architectures also performs sequential gets to all known
architectures, which acts as a multiplier to the webhook latency.

In case the webhook validates an pod with 2 images with each 2
architectures, a total of (at least) 2 * 3 http calls will be performed.

Goal
---

This change aims at reducing the webhook timings and remove the
multiplifier effect, by doing all calls in parallel.

It also aims at removing unnecessary calls (i.e. fetching manifests for
non-supported architectures) suming up to the overall latency
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>