### PR TITLE
SCHIP-3084 return error status

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -382,9 +382,6 @@ func (r *PlainRegistry) getImageManifest(ctx context.Context, client http.Client
 		return nil, err
 	}
 	r.Metrics.Responses.WithLabelValues(manifestKindFromMediaType(resp.Header.Get("Content-Type")), strconv.Itoa(resp.StatusCode)).Inc()
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failed to get manifest list. Unexpected status code %d. Expecting %d", resp.StatusCode, http.StatusOK)
-	}
 	return resp, nil
 }
 
@@ -459,7 +456,9 @@ func (r *PlainRegistry) listArchsWithAuth(ctx context.Context, client http.Clien
 	if err != nil {
 		return nil, err
 	}
-	fmt.Println(resp.Header)
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to get manifest list. Unexpected status code %d. Expecting %d", resp.StatusCode, http.StatusOK)
+	}
 	r.updateRemaingRateLimits(ctx, registry, resp)
 
 	response := registryManifestListResponse{}


### PR DESCRIPTION
# Context

Moving the status check outside of getImageManifest to avoid failing hard.

## What this PR changes

Improving the handling of errors and the behavior of the listArchsWithAuth function by moving the status check outside of the getImageManifest function to adjust error handling to differentiate between errors related to the top-level manifest and individual pointed images.



## Related Issues
https://github.com/adevinta/noe/pull/92


