### PR TITLE
Remove controller error logs

### DIFF
--- a/pkg/controllers/pod.go
+++ b/pkg/controllers/pod.go
@@ -123,7 +123,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	pod := &v1.Pod{}
 	err := r.Client.Get(ctx, req.NamespacedName, pod)
 	if client.IgnoreNotFound(err) != nil {
-		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	if apierrors.IsNotFound(err) {
@@ -140,7 +140,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 
 	ctx, podScheduledOnMatchingNode, err := r.podScheduledOnMatchingNode(ctx, req.Namespace, pod, podImages)
 	if err != nil {
-		return ctrl.Result{Requeue: true, RequeueAfter: 10 * time.Second}, err
+		return ctrl.Result{}, err
 	}
 
 	r.addToCache(req.NamespacedName.String(), podImages)

--- a/pkg/controllers/pod_test.go
+++ b/pkg/controllers/pod_test.go
@@ -825,8 +825,12 @@ func TestReconcileShouldRequeuedWhenNodeSpecGetError(t *testing.T) {
 
 	result, err := reconciler.Reconcile(context.Background(), reconcile.Request{NamespacedName: types.NamespacedName{Name: "test-pod-1", Namespace: "ns"}})
 	assert.Error(t, err)
-	assert.True(t, result.Requeue)
-
+	assert.Empty(t, result)
+	if termError, ok := err.(interface{ Is(err error) bool }); ok {
+		// Reconcile retries any error but terminal errors.
+		// Ensure this error is not terminal.
+		assert.False(t, termError.Is(reconcile.TerminalError(nil)))
+	}
 }
 
 func TestReconcileWhenPodBelongsToStatefulSetIsAlwaysChecked(t *testing.T) {


### PR DESCRIPTION
In the controller logs, we can spot warnings like

```
The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff.
For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler
```

From the controller reconciler [documenation](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler)
linked:

> // If the returned error is non-nil, the Result is ignored and the request will be
> // requeued using exponential backoff. The only exception is if the error is a
> // TerminalError in which case no requeuing happens.

Goals
---

Remove warnings in the logs
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>