### PR TITLE
Fix latest tag not being built

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,5 @@ jobs:
       run: |
         img=ghcr.io/${{github.repository}}:latest
         echo "::set-output name=IMAGE_NAME::${img}"
-        docker pull ${img} || (
-          docker buildx build --push --cache-to type=gha,mode=max --cache-from type=gha --progress plain --platform linux/arm64/v8,linux/amd64 --build-arg BUILDKIT_INLINE_CACHE=1 -t ${img}  .
-        )
+        docker buildx build --push --cache-to type=gha,mode=max --cache-from type=gha --progress plain --platform linux/arm64/v8,linux/amd64 --build-arg BUILDKIT_INLINE_CACHE=1 -t ${img}  .
 


### PR DESCRIPTION
When building a specific sha, a pull is performed to avoid re-building existing images
and ensure image immutability.

When building the latest image, we must ensure that we always provide the latest build as, by design,
there will always be an existing image with the latest tag.
Latest images being mutable
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>