### PR TITLE
Remove the need for go mod vendor

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,8 +29,6 @@ jobs:
         version: latest
         endpoint: builders
 
-    - run: go mod vendor
-
     - name: Login to Container Registry
       uses: docker/login-action@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,13 @@ WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-COPY vendor/ vendor/
 
 # Copy the go source
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
 # Build
-RUN CGO_ENABLED=0 GOARCH=$(echo ${TARGETPLATFORM:-linux/amd64} | cut -d/ -f2) go build -mod=vendor -a -o manager ./cmd/noe/main.go
+RUN CGO_ENABLED=0 GOARCH=$(echo ${TARGETPLATFORM:-linux/amd64} | cut -d/ -f2) go build -a -o manager ./cmd/noe/main.go
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 # FROM gcr.io/distroless/static:nonroot


### PR DESCRIPTION
Before opensourcing noe, it was making use of private internal
libraries.

By then, vendoring was used to avoid complex configurations of docker
build to pass the relevant credentials to private git registries.

When opensourcing Noe, we removed those dependencies but did not remove
the use of go mod vendor to build the docker image.

Goal
---

Simplify docker build and even allow running direct build of the
repository
`docker build https://github.com/adevinta/noe.git`
<details>
<summary>
Committer details
</summary>
Local-Branch: HEAD
</details>