### PR TITLE
Fix ListArchs return values.

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -598,10 +598,11 @@ func (r *PlainRegistry) ListArchs(ctx context.Context, imagePullSecret, image st
 		if len(platforms) == 0 {
 			platforms = append(platforms, Platform{Architecture: "amd64", OS: "linux"})
 		}
-		return platforms, nil
+		break
 	}
 	if err != nil {
-		return nil, err
+		return nil, errors.New("unable to find image architecture")
 	}
-	return nil, errors.New("Unable to find image architecture")
+	return platforms, nil
+
 }


### PR DESCRIPTION
Context:

Due to some third-party errors, such as issues with the registry, the listArchs function may not return an error but instead return an empty platform.

To address this, I implemented a break in the loop to exit once we successfully list architectures and I handle the return values after the loop.

# Context

<!-- Add why are we making this change -->

## What this PR changes

<!-- List the changes to the codebase behavior that will happen if this PR is merged -->
<!-- Examples: "Bumps [package-name] to version 0.18.5" -->
<!-- Examples: "Reduces number of queries made to [some api]" -->
<!-- Examples: "Improves error messaging when running [some script] fails." -->

## Validations

<!-- Is there any way to provide evidence that this PR does what it is supposed to do? Metrics? Screenshots? Shell
outputs? -->

## Related Issues

<!-- List any related issues or pull requests -->

## Checklist

- [ ] Unit tests, if necessary, have been added or updated to cover the changes made.
- [ ] Documentation (e.g. README, API docs) has been updated to reflect the changes made.
