### PR TITLE
Support excluding anymous aut for private repos

### DIFF
--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -33,6 +33,7 @@ func main() {
 	var registryProxies, matchNodeLabels string
 	var certDir string
 	var kubeletImageCredentialProviderBinBir, kubeletImageCredentialProviderConfig string
+	var privateregistriesPatterns string
 
 	flag.StringVar(&preferredArch, "preferred-arch", "amd64", "Preferred architecture when placing pods")
 	flag.StringVar(&schedulableArchs, "cluster-schedulable-archs", "", "Comma separated list of architectures schedulable in the cluster")
@@ -43,6 +44,7 @@ func main() {
 	flag.StringVar(&matchNodeLabels, "match-node-labels", "", "A set of pod label keys to match against node labels in the form of key1,key2")
 	flag.StringVar(&kubeletImageCredentialProviderBinBir, "image-credential-provider-bin-dir", "", "The path to the directory where credential provider plugin binaries are located.")
 	flag.StringVar(&kubeletImageCredentialProviderConfig, "image-credential-provider-config", "", "The path to the credential provider plugin config file.")
+	flag.StringVar(&privateregistriesPatterns, "private-registries-patterns", "", "Comma separated list of patterns to match private registries. Any image matching those patterns will be considered as private and anonymous pull will be disabled.")
 
 	flag.Parse()
 
@@ -87,7 +89,7 @@ func main() {
 		)),
 		registry.WithRegistryMetricRegistry(metrics.Registry),
 		registry.WithSchedulableArchitectures(schedulableArchSlice),
-		registry.WithAuthenticator(registry.NewAuthenticator(kubeletImageCredentialProviderConfig, kubeletImageCredentialProviderBinBir)),
+		registry.WithAuthenticator(registry.NewAuthenticator(kubeletImageCredentialProviderConfig, kubeletImageCredentialProviderBinBir, strings.Split(privateregistriesPatterns, ","))),
 	)
 	containerRegistry = registry.NewCachedRegistry(containerRegistry, 1*time.Hour, registry.WithCacheMetricsRegistry(metrics.Registry))
 

--- a/pkg/registry/anonymous_credentials.go
+++ b/pkg/registry/anonymous_credentials.go
@@ -1,10 +1,22 @@
 package registry
 
-import "context"
+import (
+	"context"
 
-type AnonymousAuthenticator struct{}
+	"github.com/adevinta/noe/pkg/log"
+)
+
+type AnonymousAuthenticator struct {
+	PrivateRegistryPatterns []string
+}
 
 func (r AnonymousAuthenticator) Authenticate(ctx context.Context, imagePullSecret, registry, image, tag string, candidates chan AuthenticationToken) {
+	for _, pattern := range r.PrivateRegistryPatterns {
+		if imageMatchesLoginPattern(ctx, registry, image, pattern) {
+			log.DefaultLogger.WithContext(ctx).WithField("pattern", pattern).WithField("image", image).WithField("registry", registry).Error("image is registered as private. Skipping anonymous authentication")
+			return
+		}
+	}
 	select {
 	case candidates <- AuthenticationToken{}:
 	case <-ctx.Done():

--- a/pkg/registry/login.go
+++ b/pkg/registry/login.go
@@ -2,6 +2,7 @@ package registry
 
 import (
 	"context"
+	"strings"
 
 	"github.com/adevinta/noe/pkg/log"
 	"github.com/spf13/afero"
@@ -32,7 +33,8 @@ func (a Authenticators) Authenticate(ctx context.Context, imagePullSecret, regis
 	}
 }
 
-func NewAuthenticator(kubeletConfigFile, kubeletBinDir string) Authenticators {
+func NewAuthenticator(kubeletConfigFile, kubeletBinDir string, privateRegistryPaterns []string) Authenticators {
+
 	fs := afero.NewOsFs()
 	a := Authenticators{
 		ImagePullSecretAuthenticator{},
@@ -45,7 +47,20 @@ func NewAuthenticator(kubeletConfigFile, kubeletBinDir string) Authenticators {
 	a = append(a,
 		ContainerDAuthenticator{fs: fs},
 		DockerConfigFileAuthenticator{fs: fs},
-		AnonymousAuthenticator{},
+		AnonymousAuthenticator{
+			PrivateRegistryPatterns: cleanRegistryPatterns(privateRegistryPaterns),
+		},
 	)
 	return a
+}
+
+func cleanRegistryPatterns(registryPatterns []string) []string {
+	r := []string{}
+	for _, pattern := range registryPatterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern != "" {
+			r = append(r, pattern)
+		}
+	}
+	return r
 }

--- a/pkg/registry/login_test.go
+++ b/pkg/registry/login_test.go
@@ -2,8 +2,54 @@ package registry
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestAuthenticateWithimagePullSecret(t *testing.T) {
+func TestNewAuthenticator(t *testing.T) {
+	t.Run("Without kubelet config, no Kubelet authenticator is added", func(t *testing.T) {
+		for _, authenticator := range NewAuthenticator("", "", []string{}) {
+			switch authenticator.(type) {
+			case KubeletAuthenticator:
+				t.Errorf("KubeletAuthenticator should not be added")
+			case ImagePullSecretAuthenticator:
+			case ContainerDAuthenticator:
+			case DockerConfigFileAuthenticator:
+			case AnonymousAuthenticator:
+			default:
+				t.Errorf("Unexpected authenticator type")
+			}
+		}
+	})
 
+	t.Run("With kubelet config, no Kubelet authenticator is added", func(t *testing.T) {
+		for _, authenticator := range NewAuthenticator("", "", []string{}) {
+			switch authenticator.(type) {
+			case KubeletAuthenticator:
+			case ImagePullSecretAuthenticator:
+			case ContainerDAuthenticator:
+			case DockerConfigFileAuthenticator:
+			case AnonymousAuthenticator:
+			default:
+				t.Errorf("Unexpected authenticator type")
+			}
+		}
+	})
+
+	t.Run("With private registry patterns, they are added to anonymous authenticator", func(t *testing.T) {
+		for _, authenticator := range NewAuthenticator("", "", []string{"", "  *.example.com", "registry.io:8080/path  "}) {
+			switch a := authenticator.(type) {
+			case KubeletAuthenticator:
+			case ImagePullSecretAuthenticator:
+			case ContainerDAuthenticator:
+			case DockerConfigFileAuthenticator:
+			case AnonymousAuthenticator:
+				assert.Contains(t, a.PrivateRegistryPatterns, "*.example.com")
+				assert.Contains(t, a.PrivateRegistryPatterns, "registry.io:8080/path")
+				assert.Len(t, a.PrivateRegistryPatterns, 2)
+			default:
+				t.Errorf("Unexpected authenticator type")
+			}
+		}
+	})
 }

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -94,7 +94,7 @@ func NewRegistryMetrics(prefix string) *RegistryMetrics {
 func NewPlainRegistry(builders ...func(*PlainRegistry)) *PlainRegistry {
 	r := PlainRegistry{
 		Scheme:        "https",
-		Authenticator: NewAuthenticator("", ""),
+		Authenticator: NewAuthenticator("", "", []string{}),
 		Proxies:       []RegistryProxy{},
 		cacheMetrics:  NewCacheMetrics("noe", "registry_authentication"),
 		Metrics:       NewRegistryMetrics("noe"),


### PR DESCRIPTION
When working with private registries, platform administrators may be
able to instruct, in advance patterns of images that will require
authentication.

Excluding those images from Anonymous authenticator would help reduce
the noise of Unauthorized response codes from registries and better
identify real problems.
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>