### PR TITLE
doc: add documentation on how to inspect image metadata when troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,3 +217,67 @@ If you specify both a preferred architecture and a list of supported architectur
 
 If a preferred architecture is specified at the Pod level and is not compatible with the supported architectures listed in the command line, it will be ignored.
 
+## Troubleshooting guide
+
+
+### Image inspection
+
+This guide explain how to inspect container images to verify the supported architectures in case Noe's selection is not as expected.
+
+1. Authenticate with the registry (if required)
+
+```bash
+# in case of using docker
+docker login <registry-url>
+```
+
+2. Fetch the Image Manifest
+
+using a token/credential from the previous step, depending on the registry
+
+#### Docker Hub
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+     https://registry-1.docker.io/v2/<repository>/manifests/<tag>
+```
+
+#### Artifactory
+```bash
+export TOKEN=$(echo -n 'username:password' | base64)
+curl -H "Authorization: Basic $TOKEN" \
+     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+     https://<artifactory-url>/v2/<repository>/manifests/<tag>
+```
+
+3. Inspect the manifest
+
+in case of multi-archs
+
+```json
+{
+"manifests": [
+  {
+    "platform": {
+      "architecture": "amd64",
+      "os": "linux"
+    }
+  },
+  {
+    "platform": {
+      "architecture": "arm64",
+      "os": "linux"
+    }
+  }
+]
+}
+```
+
+In a single-architecture manifest:
+```json
+{
+  "architecture": "amd64",
+  "os": "linux"
+}
+```

--- a/README.md
+++ b/README.md
@@ -66,13 +66,6 @@ proxies: []
 Example:
 ```yaml
 proxies:
-- docker.io=docker-proxy.company.corp
-- quay.io=quay-proxy.company.corp
-```
-
-Example:
-```yaml
-proxies:
   - docker.io=docker-proxy.company.corp
   - quay.io=quay-proxy.company.corp
 ```

--- a/README.md
+++ b/README.md
@@ -231,29 +231,19 @@ This guide explain how to inspect container images to verify the supported archi
 docker login <registry-url>
 ```
 
-2. Fetch the Image Manifest
-
-using a token/credential from the previous step, depending on the registry
-
-#### Docker Hub
+2. Inspect the manifest
 
 ```bash
-curl -H "Authorization: Bearer <token>" \
-     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
-     https://registry-1.docker.io/v2/<repository>/manifests/<tag>
+docker manifest inspect <regitry>/<repository>/<image>:<tag>
 ```
 
-#### Artifactory
+for example:
+
 ```bash
-export TOKEN=$(echo -n 'username:password' | base64)
-curl -H "Authorization: Basic $TOKEN" \
-     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
-     https://<artifactory-url>/v2/<repository>/manifests/<tag>
+docker manifest inspect docker.io/fluent/fluent-bit:2.1.10
 ```
 
-3. Inspect the manifest
-
-in case of multi-archs
+You should find the detail such as
 
 ```json
 {
@@ -271,13 +261,5 @@ in case of multi-archs
     }
   }
 ]
-}
-```
-
-In a single-architecture manifest:
-```json
-{
-  "architecture": "amd64",
-  "os": "linux"
 }
 ```


### PR DESCRIPTION
# Context

Add documentation for troubleshooting a container image's architecture

## What this PR changes

- Add documentation for troubleshooting a container image architecture


## Validations

```
curl -H "Authorization: Basic $TOKEN" \
     -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
     https://dockerhub.containers.mpi-internal.com/v2/fluent/fluent-bit/manifests/2.1.10
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 3839,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 3839,
      "platform": {
        "architecture": "arm64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 3839,
      "platform": {
        "architecture": "arm",
        "os": "linux",
        "variant": "v7"
      }
    }
  ]
}
```
