### PR TITLE
Restrict prometheus port to 8080

### DIFF
--- a/charts/noe/templates/webhook.yaml
+++ b/charts/noe/templates/webhook.yaml
@@ -25,6 +25,7 @@ metadata:
   name: {{ .Release.Name }}
   annotations:
     prometheus.io/scrape: "true"
+    prometheus.io/port: "8080"
     {{ if and .Values.deployment .Values.deployment.annotations }}
 {{ .Values.deployment.annotations | toYaml | indent 4 }}
     {{ end }}
@@ -42,6 +43,7 @@ spec:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
         {{ if and .Values.pod .Values.pod.annotations }}
 {{ .Values.pod.annotations | toYaml | indent 8 }}
         {{ end }}


### PR DESCRIPTION
Noe exposes 2 ports, with the new go versions, we see a lot of "client sent an HTTP request to an HTTPS server" errors.

The goal is to prevent prometheus from querying https ports and get rid of those logs

# Context

<!-- Add why are we making this change -->

## What this PR changes

<!-- List the changes to the codebase behavior that will happen if this PR is merged -->
<!-- Examples: "Bumps [package-name] to version 0.18.5" -->
<!-- Examples: "Reduces number of queries made to [some api]" -->
<!-- Examples: "Improves error messaging when running [some script] fails." -->

## Validations

<!-- Is there any way to provide evidence that this PR does what it is supposed to do? Metrics? Screenshots? Shell
outputs? -->

## Related Issues

<!-- List any related issues or pull requests -->

## Checklist

- [ ] Unit tests, if necessary, have been added or updated to cover the changes made.
- [ ] Documentation (e.g. README, API docs) has been updated to reflect the changes made.
