### PR TITLE
(feat) - Add High Availability Support with Leader Election

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,30 @@ You should find the detail such as
 ]
 }
 ```
+
+## High Availability (HA) Deployment
+
+Noe supports High Availability deployment with leader election to ensure zero-downtime webhook processing.
+
+### HA Architecture
+
+- **Webhook Component**: All replicas actively process admission requests (load balanced by API server)  
+- **Controller Component**: Only the leader processes pod reconciliation/eviction (followers standby)
+
+### Configuration
+
+```yaml
+leaderElection:
+  enabled: true  # Automatically: 2 replicas + leader election + PDB
+```
+
+**When `leaderElection.enabled=true`:**
+- Automatically sets `replicas: 2`
+- Enables leader election with sensible defaults
+- Creates PodDisruptionBudget with `minAvailable: 1`
+- Adds pod anti-affinity rules to spread replicas across nodes
+
+**When `leaderElection.enabled=false` (default):**  
+- Single replica deployment
+- No leader election overhead
+- Suitable for development/testing

--- a/README.md
+++ b/README.md
@@ -270,23 +270,23 @@ Noe supports High Availability deployment with leader election to ensure zero-do
 
 ### HA Architecture
 
-- **Webhook Component**: All replicas actively process admission requests (load balanced by API server)  
+- **Webhook Component**: All replicas actively process admission requests (load balanced by Kubernetes service)  
 - **Controller Component**: Only the leader processes pod reconciliation/eviction (followers standby)
 
 ### Configuration
 
 ```yaml
-leaderElection:
+ha:
   enabled: true  # Automatically: 2 replicas + leader election + PDB
 ```
 
-**When `leaderElection.enabled=true`:**
+**When `ha.enabled=true`:**
 - Automatically sets `replicas: 2`
 - Enables leader election with sensible defaults
 - Creates PodDisruptionBudget with `minAvailable: 1`
 - Adds pod anti-affinity rules to spread replicas across nodes
 
-**When `leaderElection.enabled=false` (default):**  
+**When `ha.enabled=false` (default):**  
 - Single replica deployment
 - No leader election overhead
 - Suitable for development/testing

--- a/charts/noe/templates/poddisruptionbudget.yaml
+++ b/charts/noe/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.leaderElection.enabled }}
+{{- if .Values.ha.enabled }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/noe/templates/poddisruptionbudget.yaml
+++ b/charts/noe/templates/poddisruptionbudget.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.leaderElection.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}-pdb
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}
+{{- end }}

--- a/charts/noe/templates/rolebinding.yaml
+++ b/charts/noe/templates/rolebinding.yaml
@@ -75,6 +75,17 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/noe/templates/webhook.yaml
+++ b/charts/noe/templates/webhook.yaml
@@ -35,7 +35,7 @@ metadata:
 {{ .Values.deployment.labels | toYaml | indent 4 }}
     {{ end }}
 spec:
-  replicas: {{ if .Values.leaderElection.enabled }}2{{ else }}1{{ end }}
+  replicas: {{ if .Values.ha.enabled }}2{{ else }}1{{ end }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}
@@ -54,7 +54,7 @@ spec:
         {{ end }}
     spec:
       serviceAccountName: {{ .Release.Name }}
-      {{- if .Values.leaderElection.enabled }}
+      {{- if .Values.ha.enabled }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -100,7 +100,7 @@ spec:
         args:
         - --registry-proxies={{ .Values.proxies | join "," }}
         - --cluster-schedulable-archs={{ .Values.schedulableArchitectures | join "," }}
-        {{- if .Values.leaderElection.enabled }}
+        {{- if .Values.ha.enabled }}
         - --leader-elect=true
         {{- end }}
 {{ if and .Values.kubeletConfig .Values.kubeletConfig.binDir }}

--- a/charts/noe/templates/webhook.yaml
+++ b/charts/noe/templates/webhook.yaml
@@ -100,7 +100,6 @@ spec:
         args:
         - --registry-proxies={{ .Values.proxies | join "," }}
         - --cluster-schedulable-archs={{ .Values.schedulableArchitectures | join "," }}
-        - --health-probe-addr=:8081
         {{- if .Values.leaderElection.enabled }}
         - --leader-elect=true
         {{- end }}

--- a/charts/noe/templates/webhook.yaml
+++ b/charts/noe/templates/webhook.yaml
@@ -35,7 +35,7 @@ metadata:
 {{ .Values.deployment.labels | toYaml | indent 4 }}
     {{ end }}
 spec:
-  replicas: 1
+  replicas: {{ if .Values.leaderElection.enabled }}2{{ else }}1{{ end }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}
@@ -54,6 +54,17 @@ spec:
         {{ end }}
     spec:
       serviceAccountName: {{ .Release.Name }}
+      {{- if .Values.leaderElection.enabled }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchLabels:
+                  app: {{ .Release.Name }}
+              topologyKey: kubernetes.io/hostname
+      {{- end }}
       volumes:
       - name: certs
         secret:
@@ -89,6 +100,10 @@ spec:
         args:
         - --registry-proxies={{ .Values.proxies | join "," }}
         - --cluster-schedulable-archs={{ .Values.schedulableArchitectures | join "," }}
+        - --health-probe-addr=:8081
+        {{- if .Values.leaderElection.enabled }}
+        - --leader-elect=true
+        {{- end }}
 {{ if and .Values.kubeletConfig .Values.kubeletConfig.binDir }}
         - --image-credential-provider-bin-dir={{ .Values.kubeletConfig.binDir }}
 {{ end }}
@@ -103,6 +118,20 @@ spec:
           name: webhook
         - containerPort: 8080
           name: metrics
+        - containerPort: 8081
+          name: health
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: health
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: health
+          initialDelaySeconds: 5
+          periodSeconds: 10
         volumeMounts:
         - name: certs
           mountPath: /workdir

--- a/charts/noe/values.yaml
+++ b/charts/noe/values.yaml
@@ -2,6 +2,10 @@ dockerConfigPathCandidates:
 - /var/lib/kubelet/config.json
 # - /.docker/config.json
 # - /var/lib/kubelet/.dockercfg
+
+leaderElection:
+  enabled: false
+
 image:
   registry: ghcr.io
   repository: adevinta/noe

--- a/charts/noe/values.yaml
+++ b/charts/noe/values.yaml
@@ -3,7 +3,7 @@ dockerConfigPathCandidates:
 # - /.docker/config.json
 # - /var/lib/kubelet/.dockercfg
 
-leaderElection:
+ha:
   enabled: false
 
 image:

--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -36,7 +36,7 @@ func main() {
 	var kubeletImageCredentialProviderBinBir, kubeletImageCredentialProviderConfig string
 	var privateregistriesPatterns string
 	var enableLeaderElection bool
-	var leaderElectionID string
+	const leaderElectionID string = "noe-controller-leader"
 
 	flag.StringVar(&preferredArch, "preferred-arch", "amd64", "Preferred architecture when placing pods")
 	flag.StringVar(&schedulableArchs, "cluster-schedulable-archs", "", "Comma separated list of architectures schedulable in the cluster")
@@ -45,7 +45,6 @@ func main() {
 	flag.StringVar(&healthProbeAddr, "health-probe-addr", ":8081", "The address the health probe endpoint binds to.")
 	flag.StringVar(&certDir, "cert-dir", "./", "The directory where the TLS certificates are stored")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false, "Enable leader election for controller manager.")
-	flag.StringVar(&leaderElectionID, "leader-election-id", "noe-controller-leader", "The name of the resource object that is used for locking during leader election.")
 	flag.StringVar(&registryProxies, "registry-proxies", "", "Proxies to substitute in the registry URL in the form of docker.io=docker-proxy.company.corp,quay.io=quay-proxy.company.corp")
 	flag.StringVar(&matchNodeLabels, "match-node-labels", "", "A set of pod label keys to match against node labels in the form of key1,key2")
 	flag.StringVar(&kubeletImageCredentialProviderBinBir, "image-credential-provider-bin-dir", "", "The path to the directory where credential provider plugin binaries are located.")


### PR DESCRIPTION
# Problem Statement

Noe controller currently runs as a single replica, If the controller pod fails, the webhook admission requests become unavailable.

This leads to a possible pod being misplaced when the noe pod is not available.

## Proposal
Implemented a simplified High Availability architecture.

### Webhook Component (Admission Controller)
- No leader election needed - All replicas can safely process webhook requests simultaneously, load balanced under Kubernetes service/endpoint

### Controller Component (Reconciler)
- Leader election required - Only one replica actively processes pod eviction to prevent race conditions (evict pod that's already being evicted)
- Automatic failover - Followers standby and compete for leadership when leader fails

✅ Implemented health endpoints (/healthz, /readyz on port 8081)
✅ Updated Helm template with conditional replica count and anti-affinity
✅ Fixed 2 replicas for HA set up to simplify set up
✅ Automatic PodDisruptionBudget creation for HA deployments
✅ Added comprehensive documentation to README