### PR TITLE
Make preferred architexture empty by default

### DIFF
--- a/charts/noe/templates/webhook.yaml
+++ b/charts/noe/templates/webhook.yaml
@@ -88,7 +88,9 @@ spec:
         workingDir: /workdir
         args:
         - --registry-proxies={{ .Values.proxies | join "," }}
+{{ if .Values.schedulableArchitectures }}
         - --cluster-schedulable-archs={{ .Values.schedulableArchitectures | join "," }}
+{{ end }}
 {{ if and .Values.kubeletConfig .Values.kubeletConfig.binDir }}
         - --image-credential-provider-bin-dir={{ .Values.kubeletConfig.binDir }}
 {{ end }}
@@ -97,6 +99,9 @@ spec:
 {{ end }}
 {{ if .Values.privateRegistries }}
         - --private-registries={{ .Values.privateRegistries | join "," }}
+{{ end }}
+{{ if .Values.preferredArchitecture }}
+        - --preferred-arch={{ .Values.preferredArchitecture }}
 {{ end }}
         ports:
         - containerPort: 8443

--- a/charts/noe/values.yaml
+++ b/charts/noe/values.yaml
@@ -6,6 +6,7 @@ image:
   registry: ghcr.io
   repository: adevinta/noe
   tag: latest
+preferredArchitecture: ""
 schedulableArchitectures: []
 proxies: []
 # - docker.io=docker-proxy.company.corp

--- a/cmd/noe/main.go
+++ b/cmd/noe/main.go
@@ -35,7 +35,7 @@ func main() {
 	var kubeletImageCredentialProviderBinBir, kubeletImageCredentialProviderConfig string
 	var privateregistriesPatterns string
 
-	flag.StringVar(&preferredArch, "preferred-arch", "amd64", "Preferred architecture when placing pods")
+	flag.StringVar(&preferredArch, "preferred-arch", "", "Preferred architecture when placing pods")
 	flag.StringVar(&schedulableArchs, "cluster-schedulable-archs", "", "Comma separated list of architectures schedulable in the cluster")
 	flag.StringVar(&systemOS, "system-os", "linux", "Sole OS supported by the system")
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")


### PR DESCRIPTION
An empty preferred architecture is supported and means a selector for all
matching arthitectures should be set.

Make this behviour the default one, while keeping the ability to
provide a preferred architecture on the CLI and the chart
<details>
<summary>
Committer details
</summary>
Local-Branch: main
</details>